### PR TITLE
Allow deploy script to take Neptune DB Instance Type

### DIFF
--- a/source/common/changes/@cdf/assetlibrary/fix_allow_selection_of_neptune_db_instance_type_2021-09-21-11-49.json
+++ b/source/common/changes/@cdf/assetlibrary/fix_allow_selection_of_neptune_db_instance_type_2021-09-21-11-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@cdf/assetlibrary",
+      "comment": "Allow selection of neptune DB instance from deployment scripts",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cdf/assetlibrary",
+  "email": "aaron.pittenger@bissell.com"
+}

--- a/source/infrastructure/cfn-cdf-core-services-A.yaml
+++ b/source/infrastructure/cfn-cdf-core-services-A.yaml
@@ -272,6 +272,7 @@ Parameters:
     Type: String
     Default: db.r4.xlarge
     AllowedValues:
+      - db.t3.medium
       - db.r4.large
       - db.r4.xlarge
       - db.r4.2xlarge

--- a/source/infrastructure/cfn-cdf-core-services-A.yaml
+++ b/source/infrastructure/cfn-cdf-core-services-A.yaml
@@ -267,6 +267,17 @@ Parameters:
     Description: Bulk Certificates Application Configuration AssetLibrary Application
     Type: String
     Default: '{}'
+  NeptuneDbInstanceType:
+    Description: Neptune DB instance type
+    Type: String
+    Default: db.r4.xlarge
+    AllowedValues:
+      - db.r4.large
+      - db.r4.xlarge
+      - db.r4.2xlarge
+      - db.r4.4xlarge
+      - db.r4.8xlarge
+    ConstraintDescription: Must be a valid Neptune instance type.
 
   NeptuneSnapshotIdentifier:
     Type: String
@@ -331,6 +342,7 @@ Resources:
         EnableApiGatewayAccessLogs: !Ref EnableApiGatewayAccessLogs
         KmsKeyId: !Ref KmsKeyId
         NeptuneSnapshotIdentifier: !Ref NeptuneSnapshotIdentifier
+        NeptuneDbInstanceType: !Ref NeptuneDBInstanceType
       TimeoutInMinutes: 60
 
   AssetLibraryHistory:

--- a/source/infrastructure/cfn-cdf-core-single-stack.yaml
+++ b/source/infrastructure/cfn-cdf-core-single-stack.yaml
@@ -308,6 +308,7 @@ Parameters:
     Type: String
     Default: db.r4.xlarge
     AllowedValues:
+      - db.t3.medium
       - db.r4.large
       - db.r4.xlarge
       - db.r4.2xlarge

--- a/source/infrastructure/cfn-cdf-core-single-stack.yaml
+++ b/source/infrastructure/cfn-cdf-core-single-stack.yaml
@@ -303,6 +303,17 @@ Parameters:
     Type: String
     Description: Specifies the identifier for an existing DB cluster snapshot to restore. Refer to Neptune documentation on its use.
     Default: ''
+  NeptuneDbInstanceType:
+    Description: Neptune DB instance type
+    Type: String
+    Default: db.r4.xlarge
+    AllowedValues:
+      - db.r4.large
+      - db.r4.xlarge
+      - db.r4.2xlarge
+      - db.r4.4xlarge
+      - db.r4.8xlarge
+    ConstraintDescription: Must be a valid Neptune instance type.
 
 Conditions:
   DeployAssetLibrary: !Equals [ !Ref IncludeAssetLibrary, 'true' ]
@@ -393,6 +404,7 @@ Resources:
         DeviceMonitoringAppConfigOverride: !Ref DeviceMonitoringAppConfigOverride
         BulkCertsAppConfigOverride: !Ref BulkCertsAppConfigOverride
         NeptuneSnapshotIdentifier: !Ref NeptuneSnapshotIdentifier
+        NeptuneDbInstanceType: !Ref NeptuneDbInstanceType
       TimeoutInMinutes: 120
     DependsOn:
       - Shared

--- a/source/infrastructure/deploy-core-single-stack.bash
+++ b/source/infrastructure/deploy-core-single-stack.bash
@@ -65,6 +65,7 @@ OPTIONAL ARGUMENTS
     -m (string)   Asset Library mode ('full' or 'lite').  Defaults to full if not provided.
     -p (string)   The name of the key pair to use to deploy the Bastion EC2 host (required for Asset Library (full) mode or Private auth mode).
     -i (string)   The remote access CIDR to configure Bastion SSH access (e.g. 1.2.3.4/32) (required for Asset Library (full) mode).
+    -u (string)   The neptune DB instance type
 
     COMPILING OPTIONS:
     ------------------
@@ -93,7 +94,7 @@ EOF
 # by the service specific deployment script.
 #-------------------------------------------------------------------------------
 
-while getopts ":e:E:p:i:k:K:I:b:c:a:y:z:C:A:Nv:g:n:m:o:r:BYR:P:" opt; do
+while getopts ":e:E:p:i:k:K:I:b:c:a:u:y:z:C:A:Nv:g:n:m:o:r:BYR:P:" opt; do
   case $opt in
     e  ) ENVIRONMENT=$OPTARG;;
     E  ) CONFIG_ENVIRONMENT=$OPTARG;;
@@ -104,6 +105,7 @@ while getopts ":e:E:p:i:k:K:I:b:c:a:y:z:C:A:Nv:g:n:m:o:r:BYR:P:" opt; do
     b  ) ARTIFACTS_BUCKET=$OPTARG;;
     m  ) ASSETLIBRARY_MODE=$OPTARG;;
     c  ) CDF_INFRA_CONFIG=$OPTARG;;
+    u  ) NEPTUNE_INSTANCE_TYPE=$OPTARG;;
 
     a  ) API_GATEWAY_AUTH=$OPTARG;;
     y  ) TEMPLATE_SNIPPET_S3_URI_BASE=$OPTARG;;
@@ -282,6 +284,10 @@ if [ -n "$USE_EXISTING_VPC" ] && [ "$USE_EXISTING_VPC" = 'true' ]; then
     DEPLOY_PARAMETERS+=( ExistingPublicSubnetIds=$PUBLIC_SUBNET_IDS )
     DEPLOY_PARAMETERS+=( ExistingPrivateApiGatewayVPCEndpoint=$PRIVATE_ENDPOINT_ID )
     DEPLOY_PARAMETERS+=( ExistingPrivateRouteTableIds=$PRIVATE_ROUTE_TABLE_IDS )
+fi
+
+if [ -n "$NEPTUNE_INSTANCE_TYPE" ]; then
+  DEPLOY_PARAMETERS+=( NeptuneDbInstanceType=$NEPTUNE_INSTANCE_TYPE )
 fi
 
 if [[ "incorrect_args" -gt 0 ]]; then

--- a/source/infrastructure/deploy-core-single-stack.bash
+++ b/source/infrastructure/deploy-core-single-stack.bash
@@ -65,7 +65,13 @@ OPTIONAL ARGUMENTS
     -m (string)   Asset Library mode ('full' or 'lite').  Defaults to full if not provided.
     -p (string)   The name of the key pair to use to deploy the Bastion EC2 host (required for Asset Library (full) mode or Private auth mode).
     -i (string)   The remote access CIDR to configure Bastion SSH access (e.g. 1.2.3.4/32) (required for Asset Library (full) mode).
-    -u (string)   The neptune DB instance type
+    -u (string)   The Neptune DB Instance type. Must be from the following list (default is db.r4.xlarge):
+                  - db.t3.medium
+                  - db.r4.large
+                  - db.r4.xlarge
+                  - db.r4.2xlarge
+                  - db.r4.4xlarge
+                  - db.r4.8xlarge
 
     COMPILING OPTIONS:
     ------------------

--- a/source/infrastructure/deploy-core.bash
+++ b/source/infrastructure/deploy-core.bash
@@ -79,7 +79,13 @@ OPTIONAL ARGUMENTS
     -m (string)   Asset Library mode ('full' or 'lite').  Defaults to full if not provided.
     -p (string)   The name of the key pair to use to deploy the Bastion EC2 host (required for Asset Library (full) mode or Private auth mode).
     -i (string)   The remote access CIDR to configure Bastion SSH access (e.g. 1.2.3.4/32) (required for Asset Library (full) mode).
-    -u (string)   The neptune DB instance type
+    -u (string)   The Neptune DB Instance type. Must be from the following list (default is db.r4.xlarge):
+                  - db.t3.medium
+                  - db.r4.large
+                  - db.r4.xlarge
+                  - db.r4.2xlarge
+                  - db.r4.4xlarge
+                  - db.r4.8xlarge
 
     -x (number)   No. of concurrent executions to provision.
     -s (flag)     Apply autoscaling as defined in ./cfn-autosclaling.yml

--- a/source/infrastructure/deploy-core.bash
+++ b/source/infrastructure/deploy-core.bash
@@ -118,7 +118,7 @@ EOF
 # by the service specific deployment script.
 #-------------------------------------------------------------------------------
 
-while getopts ":e:E:c:p:i:k:K:b:a:y:z:C:A:Nv:g:n:m:o:r:I:x:sD:SBYR:P:" opt; do
+while getopts ":e:E:c:p:i:k:K:b:a:y:z:C:A:Nv:u:g:n:m:o:r:I:x:sD:SBYR:P:" opt; do
   case $opt in
     e  ) ENVIRONMENT=$OPTARG;;
     E  ) CONFIG_ENVIRONMENT=$OPTARG;;
@@ -135,6 +135,7 @@ while getopts ":e:E:c:p:i:k:K:b:a:y:z:C:A:Nv:g:n:m:o:r:I:x:sD:SBYR:P:" opt; do
     s  ) APPLY_AUTOSCALING=true;;
 
     D  ) ASSETLIBRARY_DB_SNAPSHOT_IDENTIFIER=$OPTARG;;
+    u  ) NEPTUNE_DB_INSTANCE_TYPE=$OPTARG;;
 
     S  ) NOTIFICATIONS_CUSTOM_SUBNETS=true;;
 
@@ -258,6 +259,7 @@ The AWS Connected Device Framework (CDF) will install using the following config
     -K (KMS_KEY_ALIAS)                  : $KMS_KEY_ALIAS
 
     -m (ASSETLIBRARY_MODE)              : $ASSETLIBRARY_MODE
+    -u (NEPTUNE_DB_INSTANCE_TYPE)       : $NEPTUNE_DB_INSTANCE_TYPE
     -i (BASTION_REMOTE_ACCESS_CIDR)     : $BASTION_REMOTE_ACCESS_CIDR
     -x (CONCURRENT_EXECUTIONS):         : $CONCURRENT_EXECUTIONS
     -s (APPLY_AUTOSCALING):             : $APPLY_AUTOSCALING
@@ -567,6 +569,7 @@ if [ -f "$assetlibrary_config" ]; then
         -i "$VPCE_ID" \
         -r "$PRIVATE_ROUTE_TABLE_IDS" \
         -m "$ASSETLIBRARY_MODE" \
+        -u "$NEPTUNE_DB_INSTANCE_TYPE" \
         $custom_resource_vpc_lambda_arn \
         $cognito_auth_arg \
         $lambda_invoker_auth_arg \

--- a/source/infrastructure/deploy-core.bash
+++ b/source/infrastructure/deploy-core.bash
@@ -79,6 +79,7 @@ OPTIONAL ARGUMENTS
     -m (string)   Asset Library mode ('full' or 'lite').  Defaults to full if not provided.
     -p (string)   The name of the key pair to use to deploy the Bastion EC2 host (required for Asset Library (full) mode or Private auth mode).
     -i (string)   The remote access CIDR to configure Bastion SSH access (e.g. 1.2.3.4/32) (required for Asset Library (full) mode).
+    -u (string)   The neptune DB instance type
 
     -x (number)   No. of concurrent executions to provision.
     -s (flag)     Apply autoscaling as defined in ./cfn-autosclaling.yml
@@ -555,6 +556,11 @@ if [ -f "$assetlibrary_config" ]; then
     if [ -n "$CUSTOM_RESOURCE_VPC_LAMBDA_ARN" ]; then
         custom_resource_vpc_lambda_arn="-l $CUSTOM_RESOURCE_VPC_LAMBDA_ARN"
     fi
+
+    neptune_instance_type=
+    if [ -n "$NEPTUNE_DB_INSTANCE_TYPE" ]; then
+        neptune_instance_type="-u $NEPTUNE_DB_INSTANCE_TYPE"
+    fi
     
     cd "$root_dir/packages/services/assetlibrary"
     infrastructure/deploy-cfn.bash \
@@ -569,7 +575,7 @@ if [ -f "$assetlibrary_config" ]; then
         -i "$VPCE_ID" \
         -r "$PRIVATE_ROUTE_TABLE_IDS" \
         -m "$ASSETLIBRARY_MODE" \
-        -u "$NEPTUNE_DB_INSTANCE_TYPE" \
+        $neptune_instance_type \
         $custom_resource_vpc_lambda_arn \
         $cognito_auth_arg \
         $lambda_invoker_auth_arg \

--- a/source/packages/services/assetlibrary/infrastructure/cfn-assetLibrary-parent.yaml
+++ b/source/packages/services/assetlibrary/infrastructure/cfn-assetLibrary-parent.yaml
@@ -102,6 +102,7 @@ Parameters:
     Type: String
     Default: db.r4.xlarge
     AllowedValues:
+      - db.t3.medium
       - db.r4.large
       - db.r4.xlarge
       - db.r4.2xlarge

--- a/source/packages/services/assetlibrary/infrastructure/cfn-neptune.yaml
+++ b/source/packages/services/assetlibrary/infrastructure/cfn-neptune.yaml
@@ -35,6 +35,7 @@ Parameters:
     Type: String
     Default: db.r4.xlarge
     AllowedValues:
+      - db.t3.medium
       - db.r4.large
       - db.r4.xlarge
       - db.r4.2xlarge

--- a/source/packages/services/assetlibrary/infrastructure/deploy-cfn.bash
+++ b/source/packages/services/assetlibrary/infrastructure/deploy-cfn.bash
@@ -89,7 +89,7 @@ EOF
 # Validate all arguments
 #-------------------------------------------------------------------------------
 
-while getopts ":e:c:v:g:n:m:y:z:l:C:A:i:r:x:sfD:a:R:P:" opt; do
+while getopts ":e:c:v:g:n:m:y:z:l:C:A:i:r:x:u:sfD:a:R:P:" opt; do
   case ${opt} in
 
     e  ) export ENVIRONMENT=$OPTARG;;
@@ -99,6 +99,7 @@ while getopts ":e:c:v:g:n:m:y:z:l:C:A:i:r:x:sfD:a:R:P:" opt; do
     n  ) export PRIVATE_SUBNET_IDS=$OPTARG;;
     r  ) export PRIVATE_ROUTE_TABLE_IDS=$OPTARG;;
     i  ) export PRIVATE_ENDPOINT_ID=$OPTARG;;
+    u  ) export NEPTUNE_DB_INSTANCE_TYPE=$OPTARG;;
 
     m  ) export ASSETLIBRARY_MODE=$OPTARG;;
 
@@ -178,6 +179,7 @@ Running with:
   CONFIG_LOCATION:                  $CONFIG_LOCATION
   ASSETLIBRARY_MODE:                $ASSETLIBRARY_MODE
   ASSETLIBRARY_DB_SNAPSHOT_IDENTIFIER: $ASSETLIBRARY_DB_SNAPSHOT_IDENTIFIER
+  NEPTUNE_DB_INSTANCE_TYPE:         $NEPTUNE_DB_INSTANCE_TYPE
 
   TEMPLATE_SNIPPET_S3_URI_BASE:     $TEMPLATE_SNIPPET_S3_URI_BASE
   API_GATEWAY_DEFINITION_TEMPLATE:  $API_GATEWAY_DEFINITION_TEMPLATE
@@ -222,6 +224,7 @@ if [[ "$ASSETLIBRARY_MODE" = "full" ]]; then
         PrivateRouteTableIds=$PRIVATE_ROUTE_TABLE_IDS \
         CustomResourceVPCLambdaArn=$CUSTOM_RESOURCE_LAMBDA_ARN \
         SnapshotIdentifier=$ASSETLIBRARY_DB_SNAPSHOT_IDENTIFIER \
+        NeptuneDbInstanceType=$NEPTUNE_DB_INSTANCE_TYPE
         Environment=$ENVIRONMENT \
     --capabilities CAPABILITY_NAMED_IAM \
     --no-fail-on-empty-changeset \

--- a/source/packages/services/assetlibrary/infrastructure/deploy-cfn.bash
+++ b/source/packages/services/assetlibrary/infrastructure/deploy-cfn.bash
@@ -48,6 +48,13 @@ OPTIONAL ARGUMENTS:
                   - LambdaToken
                   - ApiKey
                   - IAM
+    -u (string)   The Neptune DB Instance type. Must be from the following list (default is db.r4.xlarge):
+                  - db.t3.medium
+                  - db.r4.large
+                  - db.r4.xlarge
+                  - db.r4.2xlarge
+                  - db.r4.4xlarge
+                  - db.r4.8xlarge
 
     Required if deploying in full mode, or private api auth:
     --------------------------------------------------------
@@ -204,6 +211,11 @@ Running with:
 
 cwd=$(dirname "$0")
 
+neptune_instance_type=
+if [ -n "$NEPTUNE_DB_INSTANCE_TYPE" ]; then
+    neptune_instance_type="-u $NEPTUNE_DB_INSTANCE_TYPE"
+fi
+
 if [[ "$ASSETLIBRARY_MODE" = "full" ]]; then
 
   logTitle 'Deploying the Neptune CloudFormation template'
@@ -224,7 +236,7 @@ if [[ "$ASSETLIBRARY_MODE" = "full" ]]; then
         PrivateRouteTableIds=$PRIVATE_ROUTE_TABLE_IDS \
         CustomResourceVPCLambdaArn=$CUSTOM_RESOURCE_LAMBDA_ARN \
         SnapshotIdentifier=$ASSETLIBRARY_DB_SNAPSHOT_IDENTIFIER \
-        NeptuneDbInstanceType=$NEPTUNE_DB_INSTANCE_TYPE
+        $neptune_instance_type
         Environment=$ENVIRONMENT \
     --capabilities CAPABILITY_NAMED_IAM \
     --no-fail-on-empty-changeset \

--- a/source/packages/services/assetlibrary/infrastructure/deploy-cfn.bash
+++ b/source/packages/services/assetlibrary/infrastructure/deploy-cfn.bash
@@ -213,7 +213,7 @@ cwd=$(dirname "$0")
 
 neptune_instance_type=
 if [ -n "$NEPTUNE_DB_INSTANCE_TYPE" ]; then
-    neptune_instance_type="-u $NEPTUNE_DB_INSTANCE_TYPE"
+    neptune_instance_type="DbInstanceType=$NEPTUNE_DB_INSTANCE_TYPE"
 fi
 
 if [[ "$ASSETLIBRARY_MODE" = "full" ]]; then
@@ -236,7 +236,7 @@ if [[ "$ASSETLIBRARY_MODE" = "full" ]]; then
         PrivateRouteTableIds=$PRIVATE_ROUTE_TABLE_IDS \
         CustomResourceVPCLambdaArn=$CUSTOM_RESOURCE_LAMBDA_ARN \
         SnapshotIdentifier=$ASSETLIBRARY_DB_SNAPSHOT_IDENTIFIER \
-        $neptune_instance_type
+        $neptune_instance_type \
         Environment=$ENVIRONMENT \
     --capabilities CAPABILITY_NAMED_IAM \
     --no-fail-on-empty-changeset \


### PR DESCRIPTION
# Description
The deployment scripts don't allow the user to select the Neptune DB Instance type. For those who might want to use a smaller neptune DB (like t3.medium) in dev environments to save a little money, this will be an effective way to do so.

## Type of change

- [x] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change requires a documentation update*

# Submission Checklist

- [x] Build Verified
- [x] Bundle Verified
- [x] Lint passing
- [x] Unit tests passing
- [ ] Integration tests passing
- [x] Change logs generated 

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->

