### PR TITLE
Fix provisioning error handling

### DIFF
--- a/source/common/changes/@cdf/provisioning/fix_provisioning_error_handling_2021-09-21-20-50.json
+++ b/source/common/changes/@cdf/provisioning/fix_provisioning_error_handling_2021-09-21-20-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@cdf/provisioning",
+      "comment": "properly handle not found errors in provisioning",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cdf/provisioning",
+  "email": "aaron.pittenger@bissell.com"
+}

--- a/source/packages/services/provisioning/src/utils/errors.ts
+++ b/source/packages/services/provisioning/src/utils/errors.ts
@@ -20,7 +20,7 @@ export function handleError(e:Error, res:Response): void {
         || e.message.startsWith('REGISTRATION_FAILED:')) {
         res.status(400).json({error: e.message}).end();
 
-    } else if (e.message === 'NOT_FOUND') {
+    } else if (e.message === 'NOT_FOUND' || e.name === "ResourceNotFoundException") {
         res.status(404).json({error: 'Resource does not exist'}).end();
 
     } else {


### PR DESCRIPTION
# Description
The provisioning service throws a "ResourceNotFoundException" as a 500. I've seen this get thrown when trying to `deleteThing` when that thing doesn't exist in IOT core. This should probably throw a 404.

## Type of change

- [x] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change requires a documentation update*

# Submission Checklist

- [x] Build Verified
- [x] Bundle Verified
- [x] Lint passing
- [x] Unit tests passing
- [ ] Integration tests passing
- [x] Change logs generated 

##### Additional Notes:

