### PR TITLE
fix the bug in which relationship is registered without lowercasting …

### DIFF
--- a/source/common/changes/@cdf/assetlibrary/fix-case-sensitive-problem_2021-10-05-05-31.json
+++ b/source/common/changes/@cdf/assetlibrary/fix-case-sensitive-problem_2021-10-05-05-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@cdf/assetlibrary",
+      "comment": "add lowercasting to create group API",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cdf/assetlibrary",
+  "email": "tsugunao@gmail.com"
+}

--- a/source/packages/services/assetlibrary/src/groups/groups.full.service.spec.ts
+++ b/source/packages/services/assetlibrary/src/groups/groups.full.service.spec.ts
@@ -186,6 +186,10 @@ describe('GroupsService', () => {
                 d: false
             },
             groups: {
+                in: {
+                    Linked_to_a: ['pathA1', 'pathA2'],
+                    Linked_to_b: ['pathA3']
+                },
                 out: {
                     linked_to_a: ['pathA1', 'pathA2'],
                     linked_to_b: ['pathA3']
@@ -200,6 +204,10 @@ describe('GroupsService', () => {
         });
 
         const expectedValidateRelationshipsByPathArg:DirectionStringToArrayMap = {
+            in: {
+                linked_to_a: ['patha1', 'patha2'],
+                linked_to_b: ['patha3']
+            },
             out: {
                 linked_to_a: ['patha1', 'patha2'],
                 linked_to_b: ['patha3']

--- a/source/packages/services/assetlibrary/src/groups/groups.full.service.spec.ts
+++ b/source/packages/services/assetlibrary/src/groups/groups.full.service.spec.ts
@@ -201,8 +201,8 @@ describe('GroupsService', () => {
 
         const expectedValidateRelationshipsByPathArg:DirectionStringToArrayMap = {
             out: {
-                linked_to_a: ['pathA1', 'pathA2'],
-                linked_to_b: ['pathA3']
+                linked_to_a: ['patha1', 'patha2'],
+                linked_to_b: ['patha3']
             }
         };
 
@@ -250,8 +250,8 @@ describe('GroupsService', () => {
 
         const expectedValidateRelationshipsByPathArg:DirectionStringToArrayMap = {
             out: {
-                linked_to_a: ['pathA1', 'pathA2'],
-                linked_to_b: ['pathA3'],
+                linked_to_a: ['patha1', 'patha2'],
+                linked_to_b: ['patha3'],
                 parent: ['/aparent']
             }
         };

--- a/source/packages/services/assetlibrary/src/groups/groups.full.service.ts
+++ b/source/packages/services/assetlibrary/src/groups/groups.full.service.ts
@@ -113,6 +113,8 @@ export class GroupsServiceFull implements GroupsService {
     }
 
     private setIdsToLowercase(model:GroupItem) {
+        logger.debug(`groups.full.service setIdsToLowercase: in:`);
+         
         if (model.groupPath) {
             model.groupPath = model.groupPath.toLowerCase();
         }
@@ -122,6 +124,41 @@ export class GroupsServiceFull implements GroupsService {
         if (model.parentPath) {
             model.parentPath = model.parentPath.toLowerCase();
         }
+        if (model.groups) {
+            if (model.groups.in) {
+                /* lowerrcasting values */
+                Object.keys(model.groups.in).forEach(k=> {
+                    model.groups.in[k] = model.groups.in[k].map(p => {
+                        if (p===undefined) {
+                            return p;
+                        } else {
+                            return p.toLowerCase();
+                        }
+                    });
+                });
+                /* lowercasting keys */
+                model.groups.in = Object.fromEntries(
+                    Object.entries(model.groups.in).map(([k,v]) => [k.toLowerCase(),v])
+                );
+            }
+            if (model.groups.out) {
+                 /* lowerrcasting values */
+                Object.keys(model.groups.out).forEach(k=> {
+                    model.groups.out[k] = model.groups.out[k].map(p => {
+                        if (p===undefined) {
+                            return p;
+                        } else {
+                            return p.toLowerCase();
+                        }
+                    });
+                });
+                /* lowercasting keys */
+                model.groups.out = Object.fromEntries(
+                    Object.entries(model.groups.out).map(([k,v]) => [k.toLowerCase(),v])
+                );
+            }
+        }
+        logger.debug(`groups.full.service setIdsToLowercase: exit:`);
     }
 
     public  async ___test___applyProfile(model: GroupItem, applyProfile?:string) : Promise<GroupItem> {


### PR DESCRIPTION
…in group create API

# Description
<!-- Briefly describe noteworthy details -->

## Type of change

- [*] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change requires a documentation update*

# Submission Checklist

- [*] Build Verified
- [*] Bundle Verified
- [*] Lint passing
- [*] Unit tests passing
- [*] Integration tests passing
- [*] Change logs generated 

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->
This is a bug fix of create group, in which we can create a relation without lower-casting keys and values while other APIs like detachFromGroup has lower-casting inside.
