### PR TITLE
Modify event processor to allow users input eventId

### DIFF
--- a/source/common/changes/@cdf/events-processor/modify-event-processor-for-user-to-set-eventid_2021-10-12-06-37.json
+++ b/source/common/changes/@cdf/events-processor/modify-event-processor-for-user-to-set-eventid_2021-10-12-06-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@cdf/events-processor",
+      "comment": "allow users to input eventId",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cdf/events-processor",
+  "email": "tsugunao@gmail.com"
+}

--- a/source/packages/services/events-processor/src/api/events/event.service.ts
+++ b/source/packages/services/events-processor/src/api/events/event.service.ts
@@ -39,7 +39,9 @@ export class EventService  {
         this.validateEvent(resource);
 
         // set defaults
-        resource.eventId = uuid();
+        if (resource.eventId === undefined) {
+            resource.eventId = uuid();
+        }
         if (resource.enabled===undefined) {
             resource.enabled = true;
         }

--- a/source/packages/services/events-processor/src/api/events/event.service.ts
+++ b/source/packages/services/events-processor/src/api/events/event.service.ts
@@ -39,13 +39,20 @@ export class EventService  {
         this.validateEvent(resource);
 
         // set defaults
-        if (resource.eventId === undefined) {
+        if (resource.eventId===undefined) {
             resource.eventId = uuid();
         }
         if (resource.enabled===undefined) {
             resource.enabled = true;
         }
 
+        const existing = await this.eventDao.get(resource.eventId);
+        if (existing!==undefined) {
+            if (existing.id===resource.eventId) {
+                throw new Error('DUPLICATE_EVENT_ID');
+            }
+        }
+        
         // TODO: validate the conditions format
 
         const eventSource = await this.eventSourceDao.get(resource.eventSourceId);


### PR DESCRIPTION
# Description
<!-- Briefly describe noteworthy details -->
This change request is to add a feature to input eventId when user creates events. Currently eventId is created by uuid() even if a user specified eventId.

## Type of change

- [ ] *Bug fix (non-breaking change which fixes an issue)*
- [*] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change requires a documentation update*

# Submission Checklist

- [*] Build Verified
- [*] Bundle Verified
- [*] Lint passing
- [*] Unit tests passing
- [*] Integration tests passing
- [*] Change logs generated 

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->

