### PR TITLE
Modify notification swagger doc

### DIFF
--- a/source/common/changes/@cdf/events-processor/modify-notification-swagger-doc_2021-11-04-07-32.json
+++ b/source/common/changes/@cdf/events-processor/modify-notification-swagger-doc_2021-11-04-07-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@cdf/events-processor",
+      "comment": "swagger doc change",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cdf/events-processor",
+  "email": "tsugunao@gmail.com"
+}

--- a/source/packages/services/events-processor/docs/swagger.yml
+++ b/source/packages/services/events-processor/docs/swagger.yml
@@ -579,11 +579,11 @@ components:
               type: boolean
           readOnly: true
         enabled:
-          description: Enabled status
+          description: Enabled status (This is a placeholder to enable/disable notifications. Currently, not validated)
           type: boolean
           default: true
         alerted:
-          description: Alerted status
+          description: Alerted status (This is a placeholder to enable/disable notifications. Currently, not validated)
           type: boolean
           readOnly: true
       required:


### PR DESCRIPTION
# Description
Modify swagger doc of notification to reflect that enabled, alerted flags are currently placeholders.

## Type of change

- [X] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change requires a documentation update*

# Submission Checklist

- [X] Build Verified
- [X] Bundle Verified
- [X] Lint passing
- [X] Unit tests passing
- [X] Integration tests passing
- [X] Change logs generated 

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->

