### PR TITLE
Fix assetlibrary related groups

### DIFF
--- a/source/common/changes/@cdf/assetlibrary/fix_assetlibrary_related_groups_2021-11-04-19-25.json
+++ b/source/common/changes/@cdf/assetlibrary/fix_assetlibrary_related_groups_2021-11-04-19-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@cdf/assetlibrary",
+      "comment": "Removed retrieving a groups related groups when all what was needed was to check the existence of a group. Returning related groups is performing poorly where groups are supernodes - they may have hundreds of thousands, or millions, of related devices, but to return related groups the related devices still need to be read then discarded. This improvement of the query that discards the devices is to follow.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cdf/assetlibrary",
+  "email": "deanhart@amazon.com"
+}

--- a/source/packages/services/assetlibrary/src/devices/devices.full.service.ts
+++ b/source/packages/services/assetlibrary/src/devices/devices.full.service.ts
@@ -547,7 +547,7 @@ export class DevicesServiceFull implements DevicesService {
 
         // fetch the existing device / group
         const deviceFuture = this.get(deviceId, false, [], true);
-        const groupFuture = this.groupsService.get(groupPath);
+        const groupFuture = this.groupsService.get(groupPath, false);
         const results = await Promise.all([deviceFuture, groupFuture]);
         const device = results[0];
         const group = results[1];

--- a/source/packages/services/assetlibrary/src/groups/bulkgroups.controller.ts
+++ b/source/packages/services/assetlibrary/src/groups/bulkgroups.controller.ts
@@ -43,16 +43,18 @@ export class BulkGroupsController implements interfaces.Controller {
     @httpGet('')
     public async bulkGetGroups(
             @queryParam('groupPaths') groupPaths: string,
+            @queryParam('includeGroups') groups: string,
             @request() req: Request,
             @response() res: Response
         ) {
             logger.info(`bulkgroups.controller bulkGetGroups: in: groupPaths:${groupPaths}`);
             try {
+                const includeGroups = (groups!=='false');
                 let groupPathsAsArray = groupPaths.split(',');
                 // remove duplicate group paths if any
                 groupPathsAsArray = groupPathsAsArray.filter((item, index) => groupPathsAsArray.indexOf(item) === index);
 
-                const items = await this.groupsService.getBulk(groupPathsAsArray);
+                const items = await this.groupsService.getBulk(groupPathsAsArray, includeGroups);
                 const resources = this.groupsAssembler.toGroupMemberResourceList(items, req['version']);
                 res.status(200);
                 return resources;

--- a/source/packages/services/assetlibrary/src/groups/groups.full.dao.ts
+++ b/source/packages/services/assetlibrary/src/groups/groups.full.dao.ts
@@ -35,7 +35,7 @@ export class GroupsDaoFull extends BaseDaoFull {
         super(neptuneUrl, graphSourceFactory);
     }
 
-    public async get(groupPaths: string[], includeGroups?:boolean): Promise<Node[]> {
+    public async get(groupPaths: string[], includeGroups:boolean): Promise<Node[]> {
         logger.debug(`groups.full.dao get: in: groupPath: ${groupPaths}`);
 
         const dbIds:string[] = groupPaths.map(g=> `group___${g}`);

--- a/source/packages/services/assetlibrary/src/groups/groups.full.service.ts
+++ b/source/packages/services/assetlibrary/src/groups/groups.full.service.ts
@@ -44,7 +44,7 @@ export class GroupsServiceFull implements GroupsService {
         @inject(TYPES.AuthzServiceFull) private authServiceFull: AuthzServiceFull,
         @inject(TYPES.EventEmitter) private eventEmitter: EventEmitter) {}
 
-    public async get(groupPath: string, includeGroups?: boolean): Promise<GroupItem> {
+    public async get(groupPath: string, includeGroups: boolean): Promise<GroupItem> {
         logger.debug(`groups.full.service get: in: groupPath: ${groupPath}`);
 
         ow(groupPath,'groupPath', ow.string.nonEmpty);
@@ -67,8 +67,8 @@ export class GroupsServiceFull implements GroupsService {
         return model;
     }
 
-    public async getBulk(groupPaths:string[]): Promise<GroupItemList> {
-        logger.debug(`groups.full.service: getBulk: in: groupPaths: ${groupPaths}`);
+    public async getBulk(groupPaths:string[], includeGroups:boolean): Promise<GroupItemList> {
+        logger.debug(`groups.full.service: getBulk: in: groupPaths: ${groupPaths}, includeGroups:${includeGroups}`);
 
         ow(groupPaths, ow.array.nonEmpty);
 
@@ -76,7 +76,7 @@ export class GroupsServiceFull implements GroupsService {
 
         await this.authServiceFull.authorizationCheck(groupPaths, [], ClaimAccess.R);
 
-        const result = await this.groupsDao.get(groupPaths);
+        const result = await this.groupsDao.get(groupPaths, includeGroups);
 
         const model = this.groupsAssembler.toGroupItems(result);
         logger.debug(`groups.full.service get: exit: model: ${JSON.stringify(model)}`);
@@ -263,7 +263,7 @@ export class GroupsServiceFull implements GroupsService {
         }
 
         // ensure parent exists
-        const parent = await this.get(model.parentPath);
+        const parent = await this.get(model.parentPath, false);
         if (parent===undefined) {
             throw new Error ('INVALID_PARENT');
         }
@@ -300,7 +300,7 @@ export class GroupsServiceFull implements GroupsService {
 
         // if a profile to apply has been provided, apply it first
         if (applyProfile!==undefined) {
-            const existing = await this.get(model.groupPath);
+            const existing = await this.get(model.groupPath, true);
             if (existing===undefined) {
                 throw new Error('NOT_FOUND');
             }
@@ -413,7 +413,7 @@ export class GroupsServiceFull implements GroupsService {
 
         await this.authServiceFull.authorizationCheck([], [groupPath], ClaimAccess.D);
 
-        const model = await this.get(groupPath);
+        const model = await this.get(groupPath, false);
         if (model===undefined) {
             throw new Error('NOT_FOUND');
         }
@@ -448,7 +448,7 @@ export class GroupsServiceFull implements GroupsService {
 
         await this.authServiceFull.authorizationCheck([], [sourceGroupPath, targetGroupPath], ClaimAccess.U);
 
-        const sourceGroup = await this.get(sourceGroupPath);
+        const sourceGroup = await this.get(sourceGroupPath, false);
 
         const out: StringToArrayMap = {};
         out[relationship] = [targetGroupPath];

--- a/source/packages/services/assetlibrary/src/groups/groups.lite.service.ts
+++ b/source/packages/services/assetlibrary/src/groups/groups.lite.service.ts
@@ -29,7 +29,7 @@ export class GroupsServiceLite implements GroupsService {
         @inject(TYPES.GroupsAssembler) private groupsAssembler: GroupsAssembler,
         @inject(TYPES.EventEmitter) private eventEmitter: EventEmitter) {}
 
-    public async get(groupId: string): Promise<GroupItem> {
+    public async get(groupId: string, _includeGroups=false): Promise<GroupItem> {
         logger.debug(`groups.lite.service get: in: groupId: ${groupId}`);
 
         ow(groupId, ow.string.nonEmpty);

--- a/source/packages/services/assetlibrary/src/groups/groups.service.ts
+++ b/source/packages/services/assetlibrary/src/groups/groups.service.ts
@@ -17,9 +17,9 @@ import { SortKeys } from '../data/model';
 
 export interface GroupsService {
 
-    get(groupPath: string, includeGroups?: boolean): Promise<GroupItem> ;
+    get(groupPath: string, includeGroups: boolean): Promise<GroupItem> ;
 
-    getBulk(groupPaths: string[]) : Promise<GroupItemList> ;
+    getBulk(groupPaths: string[], includeGroups: boolean) : Promise<GroupItemList> ;
 
     createBulk(request:GroupItem[], applyProfile?:string) : Promise<BulkGroupsResult> ;
 


### PR DESCRIPTION
# Description
Removed retrieving a groups related groups when all what was needed was to check the existence of a group. Returning related groups is performing poorly where groups are supernodes - they may have hundreds of thousands, or millions, of related devices, but to return related groups the related devices still need to be read then discarded. This improvement of the query that discards the devices is to follow.
## Type of change

- [X] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change requires a documentation update*

# Submission Checklist

- [X] Build Verified
- [X] Bundle Verified
- [X] Lint passing
- [X] Unit tests passing
- [X] Integration tests passing
- [X] Change logs generated 

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->

