### PR TITLE
Policy service getPolicy should use policyId

### DIFF
--- a/source/common/changes/@cdf/assetlibrary-client/fix_policy_service_get_policy_2021-12-13-02-04.json
+++ b/source/common/changes/@cdf/assetlibrary-client/fix_policy_service_get_policy_2021-12-13-02-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@cdf/assetlibrary-client",
+      "comment": "getPolicy lambda invoke should use policyId",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cdf/assetlibrary-client",
+  "email": "aaron.pittenger@bissell.com"
+}

--- a/source/packages/libraries/clients/assetlibrary-client/src/client/policies.lambda.service.ts
+++ b/source/packages/libraries/clients/assetlibrary-client/src/client/policies.lambda.service.ts
@@ -94,7 +94,7 @@ export class PoliciesLambdaService extends PoliciesServiceBase implements Polici
         ow(policyId,'policyId', ow.string.nonEmpty);
 
         const event = new LambdaApiGatewayEventBuilder()
-            .setPath(super.policiesRelativeUrl())
+            .setPath(super.policyRelativeUrl(policyId))
             .setMethod('GET')
             .setHeaders(super.buildHeaders(additionalHeaders));
 


### PR DESCRIPTION
# Description
<!-- Briefly describe noteworthy details -->
The PolicyService getPolicy function doesn't currently use the policyId, which means it returns a list of all policies instead of a single policy. This will fix it to get a single policy

## Type of change

- [x] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change requires a documentation update*

# Submission Checklist

- [x] Build Verified
- [x] Bundle Verified
- [x] Lint passing
- [x] Unit tests passing
- [x] Integration tests passing
- [x] Change logs generated 

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->

