### PR TITLE
assetlibrary-client: Fix template enum string array

### DIFF
--- a/source/common/changes/@cdf/assetlibrary-client/fix_template_enum_string_array_2022-01-06-18-50.json
+++ b/source/common/changes/@cdf/assetlibrary-client/fix_template_enum_string_array_2022-01-06-18-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@cdf/assetlibrary-client",
+      "comment": "the template model lists an enum parameter, which should be a string[] listing the enum values instead of just a string",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cdf/assetlibrary-client",
+  "email": "aaron.pittenger@bissell.com"
+}

--- a/source/packages/libraries/clients/assetlibrary-client/src/client/templates.model.ts
+++ b/source/packages/libraries/clients/assetlibrary-client/src/client/templates.model.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
 export class TypeDefinitionModel {
-	properties?: { [key: string]: {type: string|string[]; format?: string; enum?: string }};
+	properties?: { [key: string]: {type: string|string[]; format?: string; enum?: string[] }};
     required?: string[];
     relations?: {
         out?: { [key: string]: string[] },


### PR DESCRIPTION
# Description
<!-- Briefly describe noteworthy details -->
The model of a template lists an `enum` parameter. This parameter accepts the list of acceptable values for that property, therefore, should be an `string[]` instead of just a `string`

## Type of change

- [x] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change requires a documentation update*

# Submission Checklist

- [x] Build Verified
- [x] Bundle Verified
- [x] Lint passing
- [x] Unit tests passing
- [ ] Integration tests passing
- [x] Change logs generated 

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->

