### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/source/common/changes/@cdf/assetlibrary/main_2022-03-29-17-16.json
+++ b/source/common/changes/@cdf/assetlibrary/main_2022-03-29-17-16.json
@@ -1,0 +1,11 @@
+{
+    "changes": [
+      {
+        "packageName": "@cdf/assetlibrary",
+        "comment": "replace deprecated String.prototype.substr()",
+        "type": "patch"
+      }
+    ],
+    "packageName": "@cdf/assetlibrary",
+    "email": "rootcommander@gmail.com"
+}

--- a/source/packages/services/assetlibrary/src/groups/groups.lite.dao.ts
+++ b/source/packages/services/assetlibrary/src/groups/groups.lite.dao.ts
@@ -64,7 +64,7 @@ export class GroupsDaoLite {
         let parent;
         const parentPath = <string> n.attributes['parentPath'];
         if (parentPath) {
-            parent = parentPath.substr(parentPath.lastIndexOf('/')+1);
+            parent = parentPath.slice(parentPath.lastIndexOf('/')+1);
         }
 
         const params:Iot.Types.CreateThingGroupRequest = {


### PR DESCRIPTION
# Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## Type of change

- [ ] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [x] *Refactor* (existing code being refactored)
- [ ] *This change requires a documentation update*

# Submission Checklist

- [ ] Build Verified
- [ ] Bundle Verified
- [x] Lint passing
- [x] Unit tests passing
- [x] Integration tests passing
- [ ] Change logs generated 

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->

