### PR TITLE
fix: remove unused config-inject dependecy from commandandcontrol client

### DIFF
--- a/source/packages/libraries/clients/commandandcontrol-client/package.json
+++ b/source/packages/libraries/clients/commandandcontrol-client/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@awssolutions/cdf-client-request-signer": "^0.0.1",
     "@awssolutions/cdf-assetlibrary-client": "^0.0.1",
-    "@awssolutions/cdf-config-inject": "^0.0.0",
     "@awssolutions/cdf-lambda-invoke": "^0.0.1",
     "dotenv-flow": "~3.2.0",
     "http-errors": "~2.0.0",


### PR DESCRIPTION
# Description
fix: remove unused config-inject dependecy from commandandcontrol client

## Type of change
- [x] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change includes a documentation update*

# Submission Checklist
- [x] Build Verified
- [x] Bundle Verified
- [x] Lint passing
- [x] Unit tests passing
- [x] Integration tests passing
- [ ] Change logs generated 

