### PR TITLE
chore: update lambda-zip util to not mark aws-sdk as external dep

### DIFF
--- a/source/packages/libraries/core/deployment-helper/infrastructure/cfn-deployment-helper-vpc.yaml
+++ b/source/packages/libraries/core/deployment-helper/infrastructure/cfn-deployment-helper-vpc.yaml
@@ -41,7 +41,7 @@ Resources:
       FunctionName: !Sub "cdf-cfnCustomResourcesVPC-${Environment}"
       CodeUri: ../bundle.zip
       Handler: lambda_custom_resource_proxy.handler
-      MemorySize: 128
+      MemorySize: 512
       Role: !GetAtt CustomResourceLambdaVPCRole.Arn
       Runtime: nodejs16.x
       Timeout: 60

--- a/source/packages/libraries/core/deployment-helper/infrastructure/cfn-deployment-helper.yaml
+++ b/source/packages/libraries/core/deployment-helper/infrastructure/cfn-deployment-helper.yaml
@@ -69,7 +69,7 @@ Resources:
       FunctionName: !Sub "cdf-cfnCustomResources-${Environment}"
       CodeUri: ../bundle.zip
       Handler: lambda_custom_resource_proxy.handler
-      MemorySize: 128
+      MemorySize: 512
       Role: !GetAtt CustomResourceLambdaRole.Arn
       Runtime: nodejs16.x
       Timeout: 60

--- a/source/packages/libraries/core/deployment-helper/src/customResources/appConfigOverride.customResource.ts
+++ b/source/packages/libraries/core/deployment-helper/src/customResources/appConfigOverride.customResource.ts
@@ -16,6 +16,7 @@ import { TYPES } from '../di/types';
 import { logger } from '../utils/logger';
 import {CustomResourceEvent} from './customResource.model';
 import { CustomResource } from './customResource';
+import AWS from 'aws-sdk'
 
 @injectable()
 export class AppConfigOverrideCustomResource implements CustomResource {

--- a/source/packages/libraries/core/deployment-helper/src/customResources/iotDeviceDefender.customResource.ts
+++ b/source/packages/libraries/core/deployment-helper/src/customResources/iotDeviceDefender.customResource.ts
@@ -18,6 +18,7 @@ import { CustomResource } from './customResource';
 import { logger } from '@awssolutions/cdf-lambda-invoke/dist/utils/logger';
 import Iot, { AuditCheckConfigurations } from 'aws-sdk/clients/iot';
 import ow from 'ow';
+import AWS from 'aws-sdk'
 
 @injectable()
 export class IotDeviceDefenderCustomResource implements CustomResource {

--- a/source/packages/libraries/core/deployment-helper/src/customResources/iotEndpoint.customresource.ts
+++ b/source/packages/libraries/core/deployment-helper/src/customResources/iotEndpoint.customresource.ts
@@ -15,6 +15,7 @@ import { injectable, inject } from 'inversify';
 import { TYPES } from '../di/types';
 import { CustomResourceEvent } from './customResource.model';
 import { CustomResource } from './customResource';
+import AWS from 'aws-sdk'
 
 @injectable()
 export class IotEndpointCustomResource implements CustomResource {

--- a/source/packages/libraries/core/deployment-helper/src/customResources/iotEvents.customresource.ts
+++ b/source/packages/libraries/core/deployment-helper/src/customResources/iotEvents.customresource.ts
@@ -15,6 +15,7 @@ import { injectable, inject } from 'inversify';
 import { TYPES } from '../di/types';
 import { CustomResourceEvent } from './customResource.model';
 import { CustomResource } from './customResource';
+import AWS from 'aws-sdk'
 
 @injectable()
 export class IotEventsCustomResource implements CustomResource {

--- a/source/packages/libraries/core/deployment-helper/src/customResources/iotFleetIndex.customresource.ts
+++ b/source/packages/libraries/core/deployment-helper/src/customResources/iotFleetIndex.customresource.ts
@@ -15,6 +15,7 @@ import { injectable, inject } from 'inversify';
 import { TYPES } from '../di/types';
 import { CustomResourceEvent } from './customResource.model';
 import { CustomResource } from './customResource';
+import AWS from 'aws-sdk'
 
 @injectable()
 export class IotFleetIndexCustomResource implements CustomResource {

--- a/source/packages/libraries/core/deployment-helper/src/customResources/iotPolicies.customresource.ts
+++ b/source/packages/libraries/core/deployment-helper/src/customResources/iotPolicies.customresource.ts
@@ -17,6 +17,7 @@ import { CustomResourceEvent } from './customResource.model';
 import { CustomResource } from './customResource';
 import { logger } from '../utils/logger';
 import ow from 'ow';
+import AWS from 'aws-sdk'
 
 @injectable()
 export class IotPoliciesCustomResource implements CustomResource {

--- a/source/packages/libraries/core/deployment-helper/src/customResources/iotRoleAlias.customResource.ts
+++ b/source/packages/libraries/core/deployment-helper/src/customResources/iotRoleAlias.customResource.ts
@@ -17,6 +17,7 @@ import { CustomResourceEvent } from './customResource.model';
 import { CustomResource } from './customResource';
 import { logger } from '../utils/logger';
 import ow from 'ow';
+import AWS from 'aws-sdk'
 
 @injectable()
 export class IotRoleAliasCustomResource implements CustomResource {

--- a/source/packages/libraries/core/deployment-helper/src/customResources/iotThingGroup.customresource.ts
+++ b/source/packages/libraries/core/deployment-helper/src/customResources/iotThingGroup.customresource.ts
@@ -19,6 +19,7 @@ import {CustomResourceEvent} from './customResource.model';
 import {CustomResource} from './customResource';
 import ow from 'ow';
 import { logger } from '../utils/logger';
+import AWS from 'aws-sdk'
 
 interface IotThingGroupCustomResourceOutput{
      thingGroupName?: string;

--- a/source/packages/libraries/core/deployment-helper/src/customResources/iotThingType.customresource.ts
+++ b/source/packages/libraries/core/deployment-helper/src/customResources/iotThingType.customresource.ts
@@ -17,6 +17,7 @@ import { CustomResourceEvent } from './customResource.model';
 import { CustomResource } from './customResource';
 import { logger } from '@awssolutions/cdf-lambda-invoke/dist/utils/logger';
 import ow from 'ow';
+import AWS from 'aws-sdk'
 
 @injectable()
 export class IotThingTypeCustomResource implements CustomResource {

--- a/source/packages/libraries/core/deployment-helper/src/customResources/s3PutObject.customResource.ts
+++ b/source/packages/libraries/core/deployment-helper/src/customResources/s3PutObject.customResource.ts
@@ -16,6 +16,7 @@ import { TYPES } from '../di/types';
 import {CustomResourceEvent} from './customResource.model';
 import { CustomResource } from './customResource';
 import { logger } from '@awssolutions/cdf-lambda-invoke/dist/utils/logger';
+import AWS from 'aws-sdk'
 
 @injectable()
 export class S3PutObjectCustomResource implements CustomResource {

--- a/source/packages/libraries/core/deployment-helper/src/customResources/stackEvents.customResource.ts
+++ b/source/packages/libraries/core/deployment-helper/src/customResources/stackEvents.customResource.ts
@@ -16,6 +16,7 @@ import { CustomResourceEvent } from "./customResource.model";
 import { CustomResource } from "./customResource";
 import { logger } from "../utils/logger";
 import ow from "ow";
+import AWS from 'aws-sdk'
 
 type StackEventPayload = { [key: string]: string };
 

--- a/source/packages/libraries/core/deployment-helper/src/customResources/vpcEndpoint.customResource.ts
+++ b/source/packages/libraries/core/deployment-helper/src/customResources/vpcEndpoint.customResource.ts
@@ -16,6 +16,7 @@ import { CustomResourceEvent } from './customResource.model';
 import { CustomResource } from './customResource';
 import { logger } from '../utils/logger';
 import { VpcEndpointRouteTableIdList, VpcEndpointSubnetIdList } from 'aws-sdk/clients/ec2';
+import AWS from 'aws-sdk'
 
 @injectable()
 export class VpcEndpointCustomResource implements CustomResource {

--- a/source/packages/libraries/core/deployment-helper/src/customResources/vpcEndpointCheck.customResource.ts
+++ b/source/packages/libraries/core/deployment-helper/src/customResources/vpcEndpointCheck.customResource.ts
@@ -14,6 +14,7 @@ import { injectable, inject } from 'inversify';
 import { TYPES } from '../di/types';
 import { CustomResourceEvent } from './customResource.model';
 import { CustomResource } from './customResource';
+import AWS from 'aws-sdk'
 
 @injectable()
 export class VpcEndpointCheckCustomResource implements CustomResource {

--- a/source/packages/libraries/core/lambda-zip/src/lambda-zip.test.ts
+++ b/source/packages/libraries/core/lambda-zip/src/lambda-zip.test.ts
@@ -44,7 +44,7 @@ describe('lambdaZip', () => {
             const passedOptions = await exec();
             expect(passedOptions.bundle).toBe(true);
             expect(passedOptions.platform).toBe('node');
-            expect(passedOptions.external).toContain('aws-sdk');
+            // expect(passedOptions.external).toContain('aws-sdk');
         });
 
         it('forwards required entry points', async () => {

--- a/source/packages/libraries/core/lambda-zip/src/lambda-zip.ts
+++ b/source/packages/libraries/core/lambda-zip/src/lambda-zip.ts
@@ -20,10 +20,14 @@ function mergeBuildOptions(userOptions: BuildOptions) {
         ...userOptions,
     };
 
+    // EDIT: disable marking aws-sdk as external until resolution of
+    // https://github.com/aws/aws-connected-device-framework/issues/135
+    // 
     // aws-sdk is always marked external when building for lambda.
     // It is added here rather than in defaults so that user options
     // cannot prevent this.
-    result.external = ['aws-sdk', ...(result.external ?? [])];
+    //
+    // result.external = ['aws-sdk', ...(result.external ?? [])];
 
     return result;
 }


### PR DESCRIPTION
# Description
chore: update lambda-zip util to not mark aws-sdk as external dep

tested in combination with https://github.com/aws/aws-connected-device-framework/pull/134 to confirm that aws-sdk is being bundled into lambda zips

this change is tracked in https://github.com/aws/aws-connected-device-framework/issues/135 and aims to unblock the node18 upgrade

## Type of change

- [ ] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [x] *Refactor* (existing code being refactored)
- [ ] *This change includes a documentation update*

# Submission Checklist

- [x] CI dry-run passing
- [x] Integration tests passing locally
- [NA] Change logs generated 

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->
