### PR TITLE
chore: fix command-and-control integ tests

### DIFF
--- a/source/packages/services/command-and-control/infrastructure/cfn-command-and-control.yml
+++ b/source/packages/services/command-and-control/infrastructure/cfn-command-and-control.yml
@@ -358,7 +358,7 @@ Resources:
       CodeUri: ../bundle.zip
       Handler: lambda_topic_command_response_handler.handler
 
-      MemorySize: 256
+      MemorySize: 512
       Role: !GetAtt LambdaExecutionRole.Arn
       Runtime: nodejs16.x
       Timeout: 30
@@ -408,7 +408,7 @@ Resources:
       CodeUri: ../bundle.zip
       Handler: lambda_shadow_command_response_handler.handler
 
-      MemorySize: 256
+      MemorySize: 512
       Role: !GetAtt LambdaExecutionRole.Arn
       Runtime: nodejs16.x
       Timeout: 30
@@ -458,7 +458,7 @@ Resources:
       CodeUri: ../bundle.zip
       Handler: lambda_job_command_response_handler.handler
 
-      MemorySize: 256
+      MemorySize: 512
       Role: !GetAtt LambdaExecutionRole.Arn
       Runtime: nodejs16.x
       Timeout: 30

--- a/source/packages/services/command-and-control/src/commands/commands.service.ts
+++ b/source/packages/services/command-and-control/src/commands/commands.service.ts
@@ -18,6 +18,7 @@ import pLimit from 'p-limit';
 import ShortUniqueId from 'short-unique-id';
 
 import { logger } from '@awssolutions/simple-cdf-logger';
+import AWS from 'aws-sdk';
 import { SendMessageResult } from 'aws-sdk/clients/sqs';
 import { TYPES } from '../di/types';
 import { MessageItem, MessageListPaginationKey } from '../messages/messages.models';

--- a/source/packages/services/command-and-control/src/messages/messages.service.ts
+++ b/source/packages/services/command-and-control/src/messages/messages.service.ts
@@ -17,6 +17,7 @@ import ow from 'ow';
 import pLimit from 'p-limit';
 
 import { logger } from '@awssolutions/simple-cdf-logger';
+import AWS from 'aws-sdk';
 import ShortUniqueId from 'short-unique-id';
 import { CommandsDao } from '../commands/commands.dao';
 import { CommandItem } from '../commands/commands.models';

--- a/source/packages/services/command-and-control/src/messages/workflow/workflow.batchTargets.ts
+++ b/source/packages/services/command-and-control/src/messages/workflow/workflow.batchTargets.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
 import { logger } from '@awssolutions/simple-cdf-logger';
+import AWS from 'aws-sdk';
 import { SendMessageResult } from 'aws-sdk/clients/sqs';
 import { inject, injectable } from 'inversify';
 import ow from 'ow';

--- a/source/packages/services/command-and-control/src/messages/workflow/workflow.job.ts
+++ b/source/packages/services/command-and-control/src/messages/workflow/workflow.job.ts
@@ -21,6 +21,7 @@ import {
 } from '@awssolutions/cdf-provisioning-client';
 
 import { logger } from '@awssolutions/simple-cdf-logger';
+import AWS from 'aws-sdk';
 import { CommandItem, JobDeliveryMethod } from '../../commands/commands.models';
 import { TYPES } from '../../di/types';
 import { MessageItem, Recipient } from '../messages.models';

--- a/source/packages/services/command-and-control/src/messages/workflow/workflow.shadow.ts
+++ b/source/packages/services/command-and-control/src/messages/workflow/workflow.shadow.ts
@@ -16,6 +16,7 @@ import { inject, injectable } from 'inversify';
 import ow from 'ow';
 
 import { logger } from '@awssolutions/simple-cdf-logger';
+import AWS from 'aws-sdk';
 import { CommandItem, ShadowDeliveryMethod } from '../../commands/commands.models';
 import { TYPES } from '../../di/types';
 import { MessageItem } from '../messages.models';

--- a/source/packages/services/command-and-control/src/messages/workflow/workflow.topic.ts
+++ b/source/packages/services/command-and-control/src/messages/workflow/workflow.topic.ts
@@ -15,6 +15,7 @@ import { inject, injectable } from 'inversify';
 import ow from 'ow';
 
 import { logger } from '@awssolutions/simple-cdf-logger';
+import AWS from 'aws-sdk';
 import { CommandItem, TopicDeliveryMethod } from '../../commands/commands.models';
 import { TYPES } from '../../di/types';
 import { MessageItem } from '../messages.models';

--- a/source/packages/services/command-and-control/src/messages/workflow/worklow.job.spec.ts
+++ b/source/packages/services/command-and-control/src/messages/workflow/worklow.job.spec.ts
@@ -2,7 +2,7 @@ import 'reflect-metadata';
 
 import { ThingsService } from '@awssolutions/cdf-provisioning-client';
 import { ThingsLambdaService } from '@awssolutions/cdf-provisioning-client/src/client/things.lambda.service';
-import { Iot } from 'aws-sdk';
+import AWS, { Iot } from 'aws-sdk';
 import createMockInstance from 'jest-create-mock-instance';
 import { CommandItem } from '../../commands/commands.models';
 import { MessageItem } from '../messages.models';

--- a/source/packages/services/command-and-control/src/responses/responses.dao.ts
+++ b/source/packages/services/command-and-control/src/responses/responses.dao.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
 import { logger } from '@awssolutions/simple-cdf-logger';
+import AWS from 'aws-sdk';
 import { DocumentClient } from 'aws-sdk/clients/dynamodb';
 import { inject, injectable } from 'inversify';
 import { TYPES } from '../di/types';

--- a/source/packages/services/command-and-control/src/utils/dynamoDb.util.ts
+++ b/source/packages/services/command-and-control/src/utils/dynamoDb.util.ts
@@ -14,6 +14,7 @@ import { DocumentClient } from 'aws-sdk/clients/dynamodb';
 import { inject, injectable } from 'inversify';
 
 import { logger } from '@awssolutions/simple-cdf-logger';
+import AWS from 'aws-sdk';
 import { TYPES } from '../di/types';
 
 @injectable()


### PR DESCRIPTION
# Description
fix command-and-control integ tests by adding some missing `aws-sdk` imports and bumping up some Lambda memory sizes

## Type of change
- [x] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change includes a documentation update*

# Submission Checklist
- [s] CI dry-run passing
- [s] Integration tests passing locally
- [NA] Change logs generated 

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->
