### PR TITLE
chore: build packages in ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,17 +25,22 @@ jobs:
         run: |
           npm install -g @microsoft/rush
       
-      - name: Install Dependencies
+      - name: Install dependencies
         shell: bash
         run: |
-          npm i
+          yarn install
+
+      - name: Build packages
+        shell: bash
+        run: |
+          yarn build
 
       - name: Run lint
         shell: bash
         run: |
-          npm run lint
+          yarn run lint
 
       - name: Run unit tests
         shell: bash
         run: |
-          npm test
+          yarn test


### PR DESCRIPTION
# Description
build packages in ci workflow

The bulkcerts service tests are failing for a real reason (there's a missing env var) and the workflow exit code still isn't being caught correctly, but progress