### PR TITLE
fix: Node18 requires us to bundle aws-sdk into lambdas, increasing th…

### DIFF
--- a/source/packages/services/certificateactivator/infrastructure/cfn-certificateactivator.yml
+++ b/source/packages/services/certificateactivator/infrastructure/cfn-certificateactivator.yml
@@ -135,7 +135,7 @@ Resources:
       Handler: certificateactivator.handler
       Layers:
         - !Ref OpenSslLambdaLayerArn
-      MemorySize: 128
+      MemorySize: 512
       Role: !GetAtt LambdaExecutionRole.Arn
       Runtime: nodejs18.x
       AutoPublishAlias: live

--- a/source/packages/services/certificatevendor/infrastructure/cfn-certificatevendor.yml
+++ b/source/packages/services/certificatevendor/infrastructure/cfn-certificatevendor.yml
@@ -269,7 +269,7 @@ Resources:
       Handler: lambda_proxy.handler
       Layers:
         - !Ref OpenSslLambdaLayerArn
-      MemorySize: 128
+      MemorySize: 512
       Role:
         !If [
           KmsKeyProvided,

--- a/source/packages/services/device-patcher/infrastructure/cfn-device-patcher.yml
+++ b/source/packages/services/device-patcher/infrastructure/cfn-device-patcher.yml
@@ -309,7 +309,7 @@ Resources:
       FunctionName: !Sub 'cdf-device-patcher-rest-${Environment}'
       CodeUri: ../bundle.zip
       Handler: lambda_apigw_proxy.handler
-      MemorySize: 256
+      MemorySize: 512
       Role: !GetAtt RESTLambdaExecutionRole.Arn
       Runtime: nodejs18.x
       Timeout: 30
@@ -353,7 +353,7 @@ Resources:
       FunctionName: !Sub 'cdf-device-patcher-sqs-${Environment}'
       CodeUri: ../bundle.zip
       Handler: lambda_sqs_proxy.handler
-      MemorySize: 256
+      MemorySize: 512
       Role: !GetAtt SQSLambdaExecutionRole.Arn
       Runtime: nodejs18.x
       AutoPublishAlias: live
@@ -385,7 +385,7 @@ Resources:
       FunctionName: !Sub 'cdf-device-patcher-ssm-${Environment}'
       CodeUri: ../bundle.zip
       Handler: lambda_sqs_ssm_proxy.handler
-      MemorySize: 256
+      MemorySize: 512
       Role: !GetAtt SSMEventsLambdaExecutionRole.Arn
       Runtime: nodejs18.x
       AutoPublishAlias: live

--- a/source/packages/services/events-processor/infrastructure/cfn-eventsProcessor.yml
+++ b/source/packages/services/events-processor/infrastructure/cfn-eventsProcessor.yml
@@ -428,7 +428,7 @@ Resources:
       FunctionName: !Sub 'cdf-eventsprocessor-rest-${Environment}'
       CodeUri: ../bundle.zip
       Handler: lambda_proxy_restapi.handler
-      MemorySize: 256
+      MemorySize: 512
       Role: !GetAtt RESTLambdaExecutionRole.Arn
       Runtime: nodejs18.x
       Timeout: 30

--- a/source/packages/services/greengrass2-installer-config-generators/infrastructure/cfn-greengrass2-installer-config-generators.yml
+++ b/source/packages/services/greengrass2-installer-config-generators/infrastructure/cfn-greengrass2-installer-config-generators.yml
@@ -105,7 +105,7 @@ Resources:
       FunctionName: !Sub 'cdf-greengrass2-manual-config-generator-${Environment}'
       CodeUri: ../bundle.zip
       Handler: lambda_manual_handler.handler
-      MemorySize: 256
+      MemorySize: 512
       Role: !GetAtt LambdaExecutionRole.Arn
       Runtime: nodejs18.x
       Timeout: 30
@@ -127,7 +127,7 @@ Resources:
       FunctionName: !Sub 'cdf-greengrass2-fleet-config-generator-${Environment}'
       CodeUri: ../bundle.zip
       Handler: lambda_fleetProvisioning_handler.handler
-      MemorySize: 256
+      MemorySize: 512
       Role: !GetAtt LambdaExecutionRole.Arn
       Runtime: nodejs18.x
       Timeout: 30

--- a/source/packages/services/greengrass2-provisioning/infrastructure/cfn-greengrass2-provisioning.yml
+++ b/source/packages/services/greengrass2-provisioning/infrastructure/cfn-greengrass2-provisioning.yml
@@ -344,7 +344,7 @@ Resources:
       CodeUri: ../bundle.zip
       Handler: lambda_apigw_proxy.handler
 
-      MemorySize: 256
+      MemorySize: 512
       Role: !GetAtt LambdaExecutionRole.Arn
       Runtime: nodejs18.x
       Timeout: 29
@@ -406,7 +406,7 @@ Resources:
       CodeUri: ../bundle.zip
       Handler: lambda_sqs_proxy.handler
 
-      MemorySize: 256
+      MemorySize: 512
       Role: !GetAtt LambdaExecutionRole.Arn
       Runtime: nodejs18.x
       Timeout: 900
@@ -469,7 +469,7 @@ Resources:
       CodeUri: ../bundle.zip
       Handler: lambda_job_execution_proxy.handler
 
-      MemorySize: 256
+      MemorySize: 512
       Role: !GetAtt LambdaExecutionRole.Arn
       Runtime: nodejs18.x
       Timeout: 30
@@ -508,7 +508,7 @@ Resources:
       CodeUri: ../bundle.zip
       Handler: lambda_ddbstream_proxy.handler
 
-      MemorySize: 256
+      MemorySize: 512
       Role: !GetAtt LambdaExecutionRole.Arn
       Runtime: nodejs18.x
       Timeout: 30

--- a/source/packages/services/organization-manager/infrastructure/cfn-organizationmanager.yml
+++ b/source/packages/services/organization-manager/infrastructure/cfn-organizationmanager.yml
@@ -259,7 +259,7 @@ Resources:
       FunctionName: !Sub 'cdf-organizationmanager-rest-${Environment}'
       CodeUri: ../bundle.zip
       Handler: lambda_proxy.handler
-      MemorySize: 256
+      MemorySize: 512
       Role: !GetAtt RESTLambdaExecutionRole.Arn
       Runtime: nodejs18.x
       Timeout: 30

--- a/source/packages/services/simulation-launcher/infrastructure/cfn-simulation-launcher.yaml
+++ b/source/packages/services/simulation-launcher/infrastructure/cfn-simulation-launcher.yaml
@@ -295,7 +295,7 @@ Resources:
       FunctionName: !Sub 'cdf-simulation-launcher-${Environment}'
       CodeUri: ../bundle.zip
       Handler: sns_proxy.handler
-      MemorySize: 128
+      MemorySize: 512
       Role: !GetAtt LambdaExecutionRole.Arn
       Runtime: nodejs18.x
       Timeout: 300


### PR DESCRIPTION
…eir size

# Description
We have to increase the size of lambdas that bundle aws-sdk because version 2 does not tree shake and Node18 required us to include it in our lambda bundles.

## Type of change

- [ ] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change includes a documentation update*

# Submission Checklist

- [ ] CI dry-run passing
- [ ] Integration tests passing locally
- [ ] Change logs generated 

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->
