### PR TITLE
fix: improve and simplify handling of pagination parameters

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest: current file",
+      //"env": { "NODE_ENV": "test" },
+      "program": "${workspaceFolder}source/common/temp/node_modules/.pnpm/jest",
+      "args": ["${fileBasenameNoExtension}", "--config", "jest.config.js"],
+      "console": "integratedTerminal",
+      "disableOptimisticBPs": true
+    }
+  ]
+}

--- a/source/cicd/integrationtestsproject_build.bash
+++ b/source/cicd/integrationtestsproject_build.bash
@@ -174,7 +174,6 @@ export CONFIG_LOCATION=$CONFIG_LOCATION
 echo running integration tests...
 
 cd source/packages/integration-tests
-npm config set @awssolutions/cdf-integration-tests:environment $ENVIRONMENT
 npm run clean
 npm run build
 npm run integration-test -- "features/assetlibrary/full/*.feature"

--- a/source/packages/services/assetlibrary-export/src/data/common.full.dao.ts
+++ b/source/packages/services/assetlibrary-export/src/data/common.full.dao.ts
@@ -103,14 +103,12 @@ export class CommonDaoFull extends BaseDaoFull {
             });
         }
 
-        // apply pagination to the related (if requested)
-        if (offset !== undefined && count !== undefined) {
-            // note: workaround for weird typescript issue. even though offset/count are declared as numbers
-            // throughout, they are being interpreted as strings within gremlin, therefore need to force to int beforehand
-            const offsetAsInt = this.typeUtils.parseInt(offset);
-            const countAsInt = this.typeUtils.parseInt(count);
-            relatedUnion.range(offsetAsInt, offsetAsInt + countAsInt);
-        }
+        // TODO: this should be done from any service that calls this, so we should replace this with a simple number/range validation
+        const { offsetAsInt, countAsInt } = this.typeUtils.parseAndValidateOffsetAndCount(
+            offset,
+            count
+        );
+        relatedUnion.range(offsetAsInt, offsetAsInt + countAsInt);
 
         // build the main part of the query, unioning the related traversers with the main entity we want to return
         let results;

--- a/source/packages/services/assetlibrary-export/src/utils/errors.ts
+++ b/source/packages/services/assetlibrary-export/src/utils/errors.ts
@@ -38,3 +38,10 @@ export function handleError(e: Error, res: Response): void {
 
     logger.error(`handleError: res.status: ${res.statusCode} ${res.statusMessage}`);
 }
+
+export class ArgumentError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ArgumentError';
+    }
+}

--- a/source/packages/services/assetlibrary-export/src/utils/typeUtils.ts
+++ b/source/packages/services/assetlibrary-export/src/utils/typeUtils.ts
@@ -11,14 +11,64 @@
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
 import { injectable } from 'inversify';
+import ow from 'ow';
+import { ArgumentError } from './errors';
 
 @injectable()
 export class TypeUtils {
-    public parseInt(val: unknown, ifNan?: number): number {
+    private readonly DEFAULT_PAGINATION_OFFSET = 0;
+    private readonly DEFAULT_PAGINATION_COUNT = 500;
+    private readonly MAX_VALID_COUNT = 10000;
+    /*
+     * TODO: this is duplicated from assetlibrary and should be moved to a common shared util.
+     * See the assetlibrary implementation for extensive notes.
+     */
+    public parseAndValidateOffsetAndCount(
+        offset?: number,
+        count?: number
+    ): { offsetAsInt: number; countAsInt: number } {
+        // use default count and offset if omitted
+        if (offset === undefined) {
+            offset = this.DEFAULT_PAGINATION_OFFSET;
+        }
+        if (count === undefined) {
+            count = this.DEFAULT_PAGINATION_COUNT;
+        }
+
+        // do the previous parse int (which should be a )
+        const offsetAsInt = this.parseIntErrorOnNaN(offset, 'offset');
+        const countAsInt = this.parseIntErrorOnNaN(count, 'label');
+
+        // this checks if they're in the specified range and also checks for undefined and converts to a number,
+        // which are unnecessary now that we have specified defaults
+        this.owCheckOptionalNumber(offsetAsInt, 0, Number.MAX_SAFE_INTEGER, 'offset');
+        this.owCheckOptionalNumber(countAsInt, 1, this.MAX_VALID_COUNT, 'count');
+
+        return {
+            offsetAsInt,
+            countAsInt,
+        };
+    }
+
+    private parseIntErrorOnNaN(val: unknown, label: string): number {
         const asInt = parseInt(val as string);
         if (isNaN(asInt)) {
-            return ifNan;
+            throw new ArgumentError(`Invalid ${label} = ${val}`);
         }
         return asInt;
     }
+
+    private owCheckOptionalNumber = (
+        num: any,
+        minSize: number,
+        maxSize: number,
+        label: string
+    ): void => {
+        if (num === undefined) {
+            return;
+        }
+        const numToCheck = Number(num);
+        ow(numToCheck, label, ow.number.greaterThanOrEqual(minSize));
+        ow(numToCheck, label, ow.number.lessThanOrEqual(maxSize));
+    };
 }

--- a/source/packages/services/assetlibrary/src/data/common.full.dao.ts
+++ b/source/packages/services/assetlibrary/src/data/common.full.dao.ts
@@ -138,14 +138,12 @@ export class CommonDaoFull extends BaseDaoFull {
             });
         }
 
-        // apply pagination to the related (if requested)
-        if (offset !== undefined && count !== undefined) {
-            // note: workaround for weird typescript issue. even though offset/count are declared as numbers
-            // throughout, they are being interpreted as strings within gremlin, therefore need to force to int beforehand
-            offset = this.typeUtils.parseInt(offset);
-            count = this.typeUtils.parseInt(count);
-            relatedUnion.range(offset, offset + count);
-        }
+        // TODO: this should be done from any service that calls this, so we should replace this with a simple number/range validation
+        const { offsetAsInt, countAsInt } = this.typeUtils.parseAndValidateOffsetAndCount(
+            offset,
+            count
+        );
+        relatedUnion.range(offsetAsInt, offsetAsInt + countAsInt);
 
         // build the main part of the query, unioning the related traversers with the main entity we want to return
         let results;

--- a/source/packages/services/assetlibrary/src/devices/devices.full.service.ts
+++ b/source/packages/services/assetlibrary/src/devices/devices.full.service.ts
@@ -45,7 +45,6 @@ import {
     SchemaValidationError,
     TemplateNotFoundError,
 } from '../utils/errors';
-import { owCheckOptionalNumber } from '../utils/inputValidation.util';
 import { TypeUtils } from '../utils/typeUtils';
 import { DevicesAssembler } from './devices.assembler';
 import { DevicesDaoFull } from './devices.full.dao';
@@ -54,8 +53,6 @@ import { DevicesService } from './devices.service';
 
 @injectable()
 export class DevicesServiceFull implements DevicesService {
-    private readonly DEFAULT_PAGINATION_COUNT = 500;
-
     constructor(
         @inject('authorization.enabled') private isAuthzEnabled: boolean,
         @inject('defaults.devices.parent.groupPath') public defaultDeviceParentGroup: string,
@@ -89,18 +86,13 @@ export class DevicesServiceFull implements DevicesService {
             )}`
         );
 
+        const { offsetAsInt, countAsInt } = this.typeUtils.parseAndValidateOffsetAndCount(
+            offset,
+            count
+        );
+
         ow(deviceId, 'deviceId', ow.string.nonEmpty);
         ow(relationship, 'relationship', ow.string.nonEmpty);
-        owCheckOptionalNumber(count, 1, 10000, 'count');
-        owCheckOptionalNumber(offset, 0, Number.MAX_SAFE_INTEGER, 'offset');
-
-        // default pagination
-        if (count === undefined) {
-            count = this.DEFAULT_PAGINATION_COUNT;
-        }
-        if (offset === undefined) {
-            offset = 0;
-        }
 
         // defaults
         if (direction === undefined || direction === null) {
@@ -118,11 +110,6 @@ export class DevicesServiceFull implements DevicesService {
         direction = direction.toLowerCase() as OmniRelationDirection;
 
         await this.authServiceFull.authorizationCheck([deviceId], [], ClaimAccess.R);
-
-        // note: workaround for weird typescript issue. even though offset/count are declared as numbers
-        // throughout, they are being interpreted as strings, therefore need to force to int beforehand
-        const offsetAsInt = this.typeUtils.parseInt(offset);
-        const countAsInt = this.typeUtils.parseInt(count);
 
         const filteredBy = {};
         if (state) {
@@ -165,18 +152,13 @@ export class DevicesServiceFull implements DevicesService {
             )}`
         );
 
+        const { offsetAsInt, countAsInt } = this.typeUtils.parseAndValidateOffsetAndCount(
+            offset,
+            count
+        );
+
         ow(deviceId, 'deviceId', ow.string.nonEmpty);
         ow(relationship, 'relationship', ow.string.nonEmpty);
-        owCheckOptionalNumber(count, 1, 10000, 'count');
-        owCheckOptionalNumber(offset, 0, Number.MAX_SAFE_INTEGER, 'offset');
-
-        // default pagination
-        if (count === undefined) {
-            count = this.DEFAULT_PAGINATION_COUNT;
-        }
-        if (offset === undefined) {
-            offset = 0;
-        }
 
         // defaults
         if (direction === undefined || direction === null) {
@@ -191,11 +173,6 @@ export class DevicesServiceFull implements DevicesService {
         relationship = relationship.toLowerCase();
         template = template.toLowerCase();
         direction = direction.toLowerCase() as OmniRelationDirection;
-
-        // note: workaround for weird typescript issue. even though offset/count are declared as numbers
-        // throughout, they are being interpreted as strings, therefore need to force to int beforehand
-        const offsetAsInt = this.typeUtils.parseInt(offset);
-        const countAsInt = this.typeUtils.parseInt(count);
 
         await this.authServiceFull.authorizationCheck([deviceId], [], ClaimAccess.R);
 

--- a/source/packages/services/assetlibrary/src/groups/groups.full.service.ts
+++ b/source/packages/services/assetlibrary/src/groups/groups.full.service.ts
@@ -34,7 +34,6 @@ import {
     SchemaValidationError,
     TemplateNotFoundError,
 } from '../utils/errors';
-import { owCheckOptionalNumber } from '../utils/inputValidation.util';
 import { TypeUtils } from '../utils/typeUtils';
 import { GroupsAssembler } from './groups.assembler';
 import { GroupsDaoFull } from './groups.full.dao';
@@ -43,8 +42,6 @@ import { GroupsService } from './groups.service';
 
 @injectable()
 export class GroupsServiceFull implements GroupsService {
-    private readonly DEFAULT_PAGINATION_COUNT = 500;
-
     constructor(
         @inject('authorization.enabled') private isAuthzEnabled: boolean,
         @inject('defaults.groups.validateAllowedParentPaths')
@@ -470,18 +467,13 @@ export class GroupsServiceFull implements GroupsService {
             )}`
         );
 
+        const { offsetAsInt, countAsInt } = this.typeUtils.parseAndValidateOffsetAndCount(
+            offset,
+            count
+        );
+
         ow(groupPath, 'groupPath', ow.string.nonEmpty);
         ow(category, 'category', ow.string.nonEmpty);
-        owCheckOptionalNumber(count, 1, 10000, 'count');
-        owCheckOptionalNumber(offset, 0, Number.MAX_SAFE_INTEGER, 'offset');
-
-        // default pagination
-        if (count === undefined) {
-            count = this.DEFAULT_PAGINATION_COUNT;
-        }
-        if (offset === undefined) {
-            offset = 0;
-        }
 
         // any ids need to be lowercase
         groupPath = groupPath.toLowerCase();
@@ -490,11 +482,6 @@ export class GroupsServiceFull implements GroupsService {
         } else {
             type = category;
         }
-
-        // note: workaround for weird typescript issue. even though offset/count are declared as numbers
-        // throughout, they are being interpreted as strings, therefore need to force to int beforehand
-        const offsetAsInt = this.typeUtils.parseInt(offset);
-        const countAsInt = this.typeUtils.parseInt(count);
 
         await this.authServiceFull.authorizationCheck([], [groupPath], ClaimAccess.R);
 
@@ -743,10 +730,13 @@ export class GroupsServiceFull implements GroupsService {
             )}`
         );
 
+        const { offsetAsInt, countAsInt } = this.typeUtils.parseAndValidateOffsetAndCount(
+            offset,
+            count
+        );
+
         ow(groupPath, 'groupPath', ow.string.nonEmpty);
         ow(relationship, 'relationship', ow.string.nonEmpty);
-        owCheckOptionalNumber(count, 1, 10000, 'count');
-        owCheckOptionalNumber(offset, 0, Number.MAX_SAFE_INTEGER, 'offset');
 
         // defaults
         if (direction === undefined || direction === null) {
@@ -763,11 +753,6 @@ export class GroupsServiceFull implements GroupsService {
             template = template.toLowerCase();
         }
         direction = direction.toLowerCase();
-
-        // note: workaround for weird typescript issue. even though offset/count are declared as numbers
-        // throughout, they are being interpreted as strings, therefore need to force to int beforehand
-        const offsetAsInt = this.typeUtils.parseInt(offset);
-        const countAsInt = this.typeUtils.parseInt(count);
 
         await this.authServiceFull.authorizationCheck([], [groupPath], ClaimAccess.R);
 
@@ -805,18 +790,13 @@ export class GroupsServiceFull implements GroupsService {
             )}`
         );
 
+        const { offsetAsInt, countAsInt } = this.typeUtils.parseAndValidateOffsetAndCount(
+            offset,
+            count
+        );
+
         ow(groupPath, 'groupPath', ow.string.nonEmpty);
         ow(relationship, 'relationship', ow.string.nonEmpty);
-        owCheckOptionalNumber(count, 1, 10000, 'count');
-        owCheckOptionalNumber(offset, 0, Number.MAX_SAFE_INTEGER, 'offset');
-
-        // default pagination
-        if (count === undefined) {
-            count = this.DEFAULT_PAGINATION_COUNT;
-        }
-        if (offset === undefined) {
-            offset = 0;
-        }
 
         // defaults
         if (direction === undefined || direction === null) {
@@ -839,11 +819,6 @@ export class GroupsServiceFull implements GroupsService {
             state = state.toLowerCase();
         }
         direction = direction.toLowerCase();
-
-        // note: workaround for weird typescript issue. even though offset/count are declared as numbers
-        // throughout, they are being interpreted as strings, therefore need to force to int beforehand
-        const offsetAsInt = this.typeUtils.parseInt(offset);
-        const countAsInt = this.typeUtils.parseInt(count);
 
         await this.authServiceFull.authorizationCheck([], [groupPath], ClaimAccess.R);
 

--- a/source/packages/services/assetlibrary/src/policies/policies.full.service.spec.ts
+++ b/source/packages/services/assetlibrary/src/policies/policies.full.service.spec.ts
@@ -16,6 +16,7 @@ import { createMockInstance } from 'jest-create-mock-instance';
 
 import { EventEmitter } from '../events/eventEmitter.service';
 import { SchemaValidatorService } from '../types/schemaValidator.full.service';
+import { TypeUtils } from '../utils/typeUtils';
 import { PoliciesAssembler } from './policies.assembler';
 import { PoliciesDaoFull } from './policies.full.dao';
 import { PoliciesServiceFull } from './policies.full.service';
@@ -27,6 +28,7 @@ describe('PoliciesService', () => {
     let mockedSchemaValidatorService: jest.Mocked<SchemaValidatorService>;
     let mockedAssembler: jest.Mocked<PoliciesAssembler>;
     let mockedEventEmitter: jest.Mocked<EventEmitter>;
+    let mockedTypeUtils: jest.Mocked<TypeUtils>;
     let instance: PoliciesService;
 
     beforeEach(() => {
@@ -34,11 +36,13 @@ describe('PoliciesService', () => {
         mockedSchemaValidatorService = createMockInstance(SchemaValidatorService);
         mockedAssembler = createMockInstance(PoliciesAssembler);
         mockedEventEmitter = createMockInstance(EventEmitter);
+        mockedTypeUtils = createMockInstance(TypeUtils);
         instance = new PoliciesServiceFull(
             mockedEventEmitter,
             mockedAssembler,
             mockedDao,
-            mockedSchemaValidatorService
+            mockedSchemaValidatorService,
+            mockedTypeUtils
         );
     });
 

--- a/source/packages/services/assetlibrary/src/search/search.assembler.spec.ts
+++ b/source/packages/services/assetlibrary/src/search/search.assembler.spec.ts
@@ -23,8 +23,6 @@ describe('SearchServiceAssembler', () => {
     let mockedDeviceAssembler: jest.Mocked<DevicesAssembler>;
     let mockedGroupAssembler: jest.Mocked<GroupsAssembler>;
 
-    let mockedTypeUtils: jest.Mocked<TypeUtils>;
-
     let mockedSearchRequest: {
         types: string | string[] | undefined;
         ntypes: string | string[] | undefined;
@@ -46,11 +44,10 @@ describe('SearchServiceAssembler', () => {
     beforeEach(() => {
         mockedDeviceAssembler = createMockInstance(DevicesAssembler);
         mockedGroupAssembler = createMockInstance(GroupsAssembler);
-        mockedTypeUtils = createMockInstance(TypeUtils);
         instance = new SearchAssembler(
             mockedDeviceAssembler,
             mockedGroupAssembler,
-            mockedTypeUtils
+            new TypeUtils()
         );
     });
 

--- a/source/packages/services/assetlibrary/src/search/search.assembler.ts
+++ b/source/packages/services/assetlibrary/src/search/search.assembler.ts
@@ -107,8 +107,12 @@ export class SearchAssembler {
             }
         }
 
-        req.offset = this.typeUtils.parseInt(offset);
-        req.count = this.typeUtils.parseInt(count);
+        const { offsetAsInt, countAsInt } = this.typeUtils.parseAndValidateOffsetAndCount(
+            offset,
+            count
+        );
+        req.offset = offsetAsInt;
+        req.count = countAsInt;
         req.sort = assembleSortKeys(sort);
 
         return req;

--- a/source/packages/services/assetlibrary/src/search/search.full.dao.ts
+++ b/source/packages/services/assetlibrary/src/search/search.full.dao.ts
@@ -17,7 +17,6 @@ import { NodeAssembler } from '../data/assembler';
 import { BaseDaoFull, NeptuneConnection } from '../data/base.full.dao';
 import { Node } from '../data/node';
 import { TYPES } from '../di/types';
-import { ArgumentError } from '../utils/errors';
 import { TypeUtils } from '../utils/typeUtils';
 import {
     FacetResults,
@@ -257,15 +256,11 @@ export class SearchDaoFull extends BaseDaoFull {
                 });
             }
 
-            // note: workaround for weird typescript issue. even though offset/count are declared as numbers
-            // throughout, they are being interpreted as strings within gremlin, therefore need to force to int beforehand
-            const offsetAsInt = this.typeUtils.parseInt(request.offset);
-            const countAsInt = this.typeUtils.parseInt(request.count);
-            if (typeof offsetAsInt !== 'number' || typeof countAsInt !== 'number') {
-                throw new ArgumentError(
-                    `Invalid offset or count, offset ${request.offset}, count ${request.count}`
-                );
-            }
+            // TODO: this should be done from any service that calls this, so we should replace this with a simple number/range validation
+            const { offsetAsInt, countAsInt } = this.typeUtils.parseAndValidateOffsetAndCount(
+                request.offset,
+                request.count
+            );
             traverser
                 .range(offsetAsInt, offsetAsInt + countAsInt)
                 .valueMap()

--- a/source/packages/services/assetlibrary/src/utils/inputValidation.util.ts
+++ b/source/packages/services/assetlibrary/src/utils/inputValidation.util.ts
@@ -69,6 +69,7 @@ export const owCheckOversizeString = (inputStr: string, size: number, label: str
     );
 };
 
+// TOOD: remove this, see typeUtils
 export const owCheckOptionalNumber = (
     num: any,
     minSize: number,

--- a/source/packages/services/assetlibrary/src/utils/typeUtils.service.spec.ts
+++ b/source/packages/services/assetlibrary/src/utils/typeUtils.service.spec.ts
@@ -21,39 +21,118 @@ describe('typeUtils', () => {
         instance = new TypeUtils();
     });
 
-    it('happy path', () => {
-        executeAndVerifySuccess(1, 1);
+    const offsetsAndExpectedSuccesses = [
+        { label: 'number as number', input: 1, expected: 1 },
+        { label: 'number as string', input: '1', expected: 1 },
+        { label: 'undefined', input: undefined, expected: 0 },
+    ];
+
+    offsetsAndExpectedSuccesses.forEach((metadata) => {
+        it(metadata.label, () => {
+            executeAndVerifySuccess(metadata.input as number, metadata.expected as any, 1, 1);
+        });
     });
 
-    it('character', () => {
-        executeAndVerifySuccess('x', undefined);
+    const invalidOffsetRegExp = new RegExp(/Invalid offset =/);
+    const negativeOffsetRegExp = new RegExp(
+        /Expected number `offset` to be greater than or equal to 0, got -1/
+    );
+    const offsetsAndExpectedFailures = [
+        { label: 'character', input: 'x', expected: invalidOffsetRegExp },
+        { label: 'null', input: null, expected: invalidOffsetRegExp },
+        { label: 'empty string', input: '', expected: invalidOffsetRegExp },
+        { label: 'space', input: '  ', expected: invalidOffsetRegExp },
+        { label: 'NaN', input: NaN, expected: invalidOffsetRegExp },
+        { label: 'negative', input: -1, expected: negativeOffsetRegExp },
+    ];
+
+    offsetsAndExpectedFailures.forEach((metadata) => {
+        it(metadata.label, () => {
+            executeAndVerifyError(
+                metadata.input as number,
+                metadata.expected as any,
+                1,
+                '1',
+                'offset'
+            );
+        });
     });
 
-    it('number as string', () => {
-        executeAndVerifySuccess('1', 1);
+    const countsAndExpectedSuccess = [
+        { label: 'number as number', input: 1, expected: 1 },
+        { label: 'number as string', input: '1', expected: 1 },
+        { label: 'undefined', input: undefined, expected: 500 }, // default is five hundred
+    ];
+
+    countsAndExpectedSuccess.forEach((metadata) => {
+        it(metadata.label, () => {
+            executeAndVerifySuccess(1, 1, metadata.input as number, metadata.expected as any);
+        });
     });
 
-    it('undefined', () => {
-        executeAndVerifySuccess(undefined, undefined);
+    const invalidCountRegExp = new RegExp(/Invalid count =/);
+    const negativeCountRegExp = new RegExp(
+        /Expected number `count` to be greater than or equal to 1, got -1/
+    );
+    const countsAndExpectedFailures = [
+        { label: 'character', input: 'x', expected: invalidCountRegExp },
+        { label: 'null', input: null, expected: invalidCountRegExp },
+        { label: 'empty string', input: '', expected: invalidCountRegExp },
+        { label: 'space', input: '  ', expected: invalidCountRegExp },
+        { label: 'NaN', input: NaN, expected: invalidCountRegExp },
+        { label: 'negative', input: -1, expected: negativeCountRegExp },
+    ];
+
+    countsAndExpectedFailures.forEach((metadata) => {
+        it(metadata.label, () => {
+            executeAndVerifyError(
+                1,
+                '1',
+                metadata.input as number,
+                metadata.expected as any,
+                'count'
+            );
+        });
     });
 
-    it('null', () => {
-        executeAndVerifySuccess(null, undefined);
-    });
-
-    it('empty string', () => {
-        executeAndVerifySuccess('', undefined);
-    });
-
-    it('space', () => {
-        executeAndVerifySuccess(' ', undefined);
-    });
-
-    function executeAndVerifySuccess(input: unknown, expected: number) {
+    function executeAndVerifySuccess(
+        offsetInput: number,
+        offsetExpected: number,
+        countInput: number,
+        countExpected: number
+    ) {
         // Make the call
-        const result = instance.parseInt(input as string);
+        try {
+            const { offsetAsInt: offsetResult, countAsInt: countResult } =
+                instance.parseAndValidateOffsetAndCount(offsetInput, countInput);
 
-        // Finally, verify the results
-        expect(result).toEqual(expected);
+            // Finally, verify the results
+            expect(offsetResult).toEqual(offsetExpected);
+            expect(countResult).toEqual(countExpected);
+        } catch (err) {
+            fail(`Should succeed but received error: ${err}`);
+        }
+    }
+
+    function executeAndVerifyError(
+        offsetInput: number,
+        offsetExpected: string | RegExp,
+        countInput: number,
+        countExpected: string | RegExp,
+        testing: 'count' | 'offset'
+    ) {
+        // Make the call
+        try {
+            const result = instance.parseAndValidateOffsetAndCount(offsetInput, countInput);
+            fail(`Call should trigger an error. Got ${result}`);
+        } catch (err) {
+            expect(err.name).toEqual('ArgumentError'); // verify the error is correct
+            // verify we expected the error and the message is correct
+            if (testing == 'offset') {
+                expect(err.message).toMatch(offsetExpected); // verify the error is correct
+            } else if (testing == 'count') {
+                expect(err.message).toMatch(countExpected); // verify the error is correct
+            }
+        }
     }
 });

--- a/source/packages/services/assetlibrary/src/utils/typeUtils.ts
+++ b/source/packages/services/assetlibrary/src/utils/typeUtils.ts
@@ -11,13 +11,60 @@
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
 import { injectable } from 'inversify';
+import { owCheckOptionalNumber } from '../utils/inputValidation.util';
+import { ArgumentError } from './errors';
 
 @injectable()
 export class TypeUtils {
-    public parseInt(val: unknown, ifNan?: number): number {
+    private readonly DEFAULT_PAGINATION_OFFSET = 0;
+    private readonly DEFAULT_PAGINATION_COUNT = 500;
+    private readonly MAX_VALID_COUNT = 10000;
+    /*
+     * This is a stop gap in a greater refactor. Url params (e.g. offset and count) are strings.
+     * Typescript does not convert them to numbers when number is declared as their type. They must be manually
+     * converted whenever it is necessary that they are numbers.
+     *
+     * Offset and Count also both require defaults (paginated APIs should default to prevent a DOS when there's significant data).
+     *
+     * Finally, they both have constraints that must be checked.
+     * This method combines that repetitive work into a single helper.
+     *
+     * TODO: remove this function. This maintains existing functionality but could be much simpler. Since offset and count
+     * should always have a default and will always initially be strings, we should only replace them if they're undefined,
+     * we should always convert them to numbers, and we should test that they are within the specified
+     * range using ow base methods instead of owCheckOptionalNumber.
+     */
+    public parseAndValidateOffsetAndCount(
+        offset?: number,
+        count?: number
+    ): { offsetAsInt: number; countAsInt: number } {
+        // use default count and offset if omitted
+        if (offset === undefined) {
+            offset = this.DEFAULT_PAGINATION_OFFSET;
+        }
+        if (count === undefined) {
+            count = this.DEFAULT_PAGINATION_COUNT;
+        }
+
+        // do the previous parse int (which should be a )
+        const offsetAsInt = this.parseIntErrorOnNaN(offset, 'offset');
+        const countAsInt = this.parseIntErrorOnNaN(count, 'count');
+
+        // this checks if they're in the specified range and also checks for undefined and converts to a number,
+        // which are unnecessary now that we have specified defaults
+        owCheckOptionalNumber(offsetAsInt, 0, Number.MAX_SAFE_INTEGER, 'offset');
+        owCheckOptionalNumber(countAsInt, 1, this.MAX_VALID_COUNT, 'count');
+
+        return {
+            offsetAsInt,
+            countAsInt,
+        };
+    }
+
+    private parseIntErrorOnNaN(val: unknown, label: string): number {
         const asInt = parseInt(val as string);
         if (isNaN(asInt)) {
-            return ifNan;
+            throw new ArgumentError(`Invalid ${label} = ${val}`);
         }
         return asInt;
     }


### PR DESCRIPTION
# Description
The changes we made to validate pagination offset and count did not catch bad input in all cases. In some, they would error on missing values even though they're optional.

This unifies the checks and conversions we need to make to those values. It also guarantees defaults for all (as a security concern, we limit the values even in the case where they're omitted to prevent a DOS).

See source/packages/services/assetlibrary/src/utils/typeUtils.ts for a full description and plans for subsequent changes.

Other changes:
- I removed `npm config set @awssolutions/cdf-integration-tests:environment $ENVIRONMENT`. NPM no longer allows adding your own values to the config, and I cannot find an example of this being used anywhere.
- I added a simple launch.json for running unit tests via VSCode for debugging as well.

Testing changes:
- I added an extensive test for one API (assetlibrary/src/groups/groups.full.service.ts#getMembers) that guarantees the TypeUtils works correctly in the context of the service functions, as it should.
- I switched to using the actual TypeUtils instead of mocks in the tests because we're not gaining much from mocking these since they're simple conversions that _must_ happen on those APIs. It's better that they're part of the test than mocked which could create the error this changeset is fixing.
- I used try/catch instead of .throwsError in jest because it seems to be more idiomatic for the extra tests we want, and a sample I did of throwsError did not work correctly with how our framework throws errors.


## Type of change

- [x] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [x] *Refactor* (existing code being refactored)
- [ ] *This change includes a documentation update*

# Submission Checklist

- [ ] CI dry-run passing
- [x] Integration tests passing locally
- [ ] Change logs generated 

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->
