### PR TITLE
fix: do not attempt sync workflow from forks

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -9,6 +9,7 @@ on:
   workflow_dispatch: {}
 jobs:
   sync:
+    if: github.repository_owner == 'aws'
     name: Sync to CodeCommit
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
# Description
Synching is a process that only exists for the original repo as a part of its build process. Forked branches should not attempt to sync since they do not have permission to do so.

## Type of change

- [x] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change includes a documentation update*

# Submission Checklist

- [ ] CI dry-run passing
- [ ] Integration tests passing locally
- [ ] Change logs generated 

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->
