### PR TITLE
feature: apply - Configurable port for MQTT and GGv2 Data Plane

### DIFF
--- a/source/common/changes/@cdf/greengrass2-installer-config-generators/feature-ggv2-mqtt-port-config_2022-08-10-01-53.json
+++ b/source/common/changes/@cdf/greengrass2-installer-config-generators/feature-ggv2-mqtt-port-config_2022-08-10-01-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@cdf/greengrass2-installer-config-generators",
+      "comment": "allow users to modify mqtt and greengrassDataPlanePort",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cdf/greengrass2-installer-config-generators",
+  "email": "joysl@amazon.com"
+}

--- a/source/common/changes/@cdf/installer/feature-ggv2-mqtt-port-config_2022-08-10-01-53.json
+++ b/source/common/changes/@cdf/installer/feature-ggv2-mqtt-port-config_2022-08-10-01-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@cdf/installer",
+      "comment": "allow users to modify mqtt and greengrassDataPlanePort ",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cdf/installer",
+  "email": "joysl@amazon.com"
+}

--- a/source/packages/services/greengrass2-installer-config-generators/src/generators/manual.generator.spec.ts
+++ b/source/packages/services/greengrass2-installer-config-generators/src/generators/manual.generator.spec.ts
@@ -27,6 +27,45 @@ describe('ManualProvisioningGenerator', () => {
         iotCredEndpoint: 'somewhere.credentials.iot.us-west-2.amazonaws.com',
     };
 
+    const handlerConfigPort: ManualProvisioningConfig = {
+        ...handlerConfig,
+        mqttPort: 443,
+        greengrassDataPlanePort: 443,
+    };
+
+    it('mqtt port test', async () => {
+        const handler = manualProvisioningHandler(handlerConfigPort);
+        const event: ConfigGeneratorEvent = {
+            coreDeviceName: 'device001',
+            version: '1.0.0',
+        };
+
+        const actual = await handler(event, undefined, undefined);
+        const expected =
+            '---\n' +
+            'system:\n' +
+            `  certificateFilePath: ${handlerConfig.certificateFilePath}\n` +
+            `  privateKeyPath: ${handlerConfig.privateKeyPath}\n` +
+            `  rootCaPath: ${handlerConfig.rootCaPath}\n` +
+            `  rootpath: ${handlerConfig.rootPath}\n` +
+            `  thingName: ${event.coreDeviceName}\n` +
+            'services:\n' +
+            '  aws.greengrass.Nucleus:\n' +
+            '    componentType: NUCLEUS\n' +
+            `    version: ${event.version}\n` +
+            '    configuration:\n' +
+            `      awsRegion: ${handlerConfig.awsRegion}\n` +
+            `      iotRoleAlias: ${handlerConfig.iotRoleAlias}\n` +
+            `      iotDataEndpoint: ${handlerConfig.iotDataEndpoint}\n` +
+            `      iotCredEndpoint: ${handlerConfig.iotCredEndpoint}\n` +
+            '      mqtt:\n' +
+            `        port: ${handlerConfigPort.mqttPort}\n` +
+            `      greengrassDataPlanePort: ${handlerConfigPort.greengrassDataPlanePort}\n`;
+
+        expect(actual).toBeDefined();
+        expect(actual['config']).toEqual(expected);
+    });
+
     it('happy path', async () => {
         const handler = manualProvisioningHandler(handlerConfig);
         const event: ConfigGeneratorEvent = {

--- a/source/packages/services/greengrass2-installer-config-generators/src/generators/manual.generator.ts
+++ b/source/packages/services/greengrass2-installer-config-generators/src/generators/manual.generator.ts
@@ -17,6 +17,7 @@ import { logger } from '@awssolutions/simple-cdf-logger';
 import { InstallerConfig } from '../installerConfig/installer.models';
 import { ConfigGeneratorEvent, ConfigGeneratorHandler } from './models';
 
+export type GG_DATA_PLANE_PORT = 8443 | 443;
 export type ManualProvisioningConfig = {
     certificateFilePath: string;
     privateKeyPath: string;
@@ -26,6 +27,8 @@ export type ManualProvisioningConfig = {
     iotRoleAlias: string;
     iotDataEndpoint: string;
     iotCredEndpoint: string;
+    mqttPort?: number;
+    greengrassDataPlanePort?: GG_DATA_PLANE_PORT;
 };
 
 export const manualProvisioningHandler =
@@ -58,6 +61,15 @@ export const manualProvisioningHandler =
             },
         };
 
+        if (handlerConfig.mqttPort) {
+            configJson.services['aws.greengrass.Nucleus'].configuration.mqtt = {
+                port: handlerConfig.mqttPort,
+            };
+        }
+        if (handlerConfig.greengrassDataPlanePort) {
+            configJson.services['aws.greengrass.Nucleus'].configuration.greengrassDataPlanePort =
+                handlerConfig.greengrassDataPlanePort;
+        }
         const doc = new Document();
         doc.directivesEndMarker = true;
         doc.contents = configJson;

--- a/source/packages/services/greengrass2-installer-config-generators/src/lambda_manual_handler.ts
+++ b/source/packages/services/greengrass2-installer-config-generators/src/lambda_manual_handler.ts
@@ -13,6 +13,7 @@
 import '@awssolutions/cdf-config-inject';
 
 import {
+    GG_DATA_PLANE_PORT,
     ManualProvisioningConfig,
     manualProvisioningHandler,
 } from './generators/manual.generator';
@@ -26,6 +27,8 @@ const handlerConfig: ManualProvisioningConfig = {
     iotRoleAlias: process.env.AWS_IOT_ROLE_ALIAS,
     iotDataEndpoint: process.env.AWS_IOT_ENDPOINT_DATA,
     iotCredEndpoint: process.env.AWS_IOT_ENDPOINT_CREDENTIALS,
+    mqttPort: parseInt(process.env.MQTT_PORT),
+    greengrassDataPlanePort: process.env.GG_DATA_PLANE_PORT as unknown as GG_DATA_PLANE_PORT,
 };
 
 exports.handler = manualProvisioningHandler(handlerConfig);

--- a/source/packages/services/installer/src/commands/modules/service/greengrass2InstallerConfigGenerators.ts
+++ b/source/packages/services/installer/src/commands/modules/service/greengrass2InstallerConfigGenerators.ts
@@ -82,6 +82,17 @@ export class Greengrass2InstallerConfigGeneratorsInstaller implements ServiceMod
                         defaultConfiguration: '/greengrass/v2/claim-certs/claim.private.pem.key',
                         question: 'Path to claim private key',
                     },
+                    {
+                        propertyName: 'mqttPort',
+                        defaultConfiguration: 8883,
+                        question: 'Please enter the port to use for MQTT. For example 443 or 8883',
+                    },
+                    {
+                        propertyName: 'greengrassDataPlanePort',
+                        defaultConfiguration: 8443,
+                        question:
+                            'Please enter the port to use for GG Data Plane. Allowed options are 8443 or 443',
+                    },
                 ]),
             ],
             updatedAnswers
@@ -197,6 +208,11 @@ export class Greengrass2InstallerConfigGeneratorsInstaller implements ServiceMod
             .add(
                 `DEVICE_CLAIM_CERTIFICATE_PRIVATE_KEY_PATH`,
                 answers.greengrass2InstallerConfigGenerators.deviceClaimCertificatePrivateKeyPath
+            )
+            .add(`MQTT_PORT`, answers.greengrass2InstallerConfigGenerators.mqttPort)
+            .add(
+                `GG_DATA_PLANE_PORT`,
+                answers.greengrass2InstallerConfigGenerators.greengrassDataPlanePort
             );
 
         return configBuilder.config;

--- a/source/packages/services/installer/src/models/answers.ts
+++ b/source/packages/services/installer/src/models/answers.ts
@@ -257,6 +257,7 @@ export interface Notifications extends RestServiceModuleAttribues {
     itemCacheTTL?: number;
 }
 
+export type GG_DATA_PLANE_PORT = 8443 | 443;
 export interface Greengrass2InstallerConfigGenerators extends ServiceModuleAttributes {
     tokenExchangeRoleAlias?: string;
     // Application Configuration
@@ -266,6 +267,8 @@ export interface Greengrass2InstallerConfigGenerators extends ServiceModuleAttri
     devicePrivateKeyPath?: string;
     deviceClaimCertificatePath?: string;
     deviceClaimCertificatePrivateKeyPath?: string;
+    mqttPort?: number;
+    greengrassDataPlanePort?: GG_DATA_PLANE_PORT;
 }
 
 export interface Greengrass2Provisioning


### PR DESCRIPTION
# Description
For engagements where the Sitewise gateway is deployed on customer n/w, the default ports for MQTT(8883) and Greengrass data plane(8443) may not works based on the IP rules set. This PR let's the customer assign the port numbers as part of the CDF deployment prompts.

## Type of change

- [ ] *Bug fix (non-breaking change which fixes an issue)*
- [x] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change includes a documentation update*

# Submission Checklist

- [ ] CI dry-run passing
- [ ] Integration tests passing locally
- [ ] Change logs generated 

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->
