### PR TITLE
fix: fix an incorrect parameter name in custom resource

### DIFF
--- a/source/packages/libraries/core/deployment-helper/src/customResources/rotateCertificatesJob.customresource.ts
+++ b/source/packages/libraries/core/deployment-helper/src/customResources/rotateCertificatesJob.customresource.ts
@@ -40,7 +40,7 @@ export class RotateCertificatesJobCustomResource implements CustomResource {
     }
 
     public async create(customResourceEvent: CustomResourceEvent): Promise<unknown> {
-        const functionName = customResourceEvent?.ResourceProperties?.FunctionName;
+        const functionName = customResourceEvent?.ResourceProperties?.CommandsFunctionName;
         const thingGroupArn = customResourceEvent?.ResourceProperties?.ThingGroupArn;
         const mqttGetTopic = customResourceEvent?.ResourceProperties?.MQTTGetTopic;
         const mqttAckTopic = customResourceEvent?.ResourceProperties?.MQTTAckTopic;


### PR DESCRIPTION
# Description
Found an issue while testing a PR. Certificate Vendor calls this with a param called CommandsFunctionName but the job is looking for FunctionName.

## Type of change

- [x] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change includes a documentation update*

# Submission Checklist

- [ ] CI dry-run passing
- [ ] Integration tests passing locally
- [ ] Change logs generated 

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->
