### PR TITLE
fix(assetlibrary): change connection life cycle between Lambda and Neptune

### DIFF
--- a/source/common/changes/@awssolutions/cdf-assetlibrary/main_2023-10-06-06-40.json
+++ b/source/common/changes/@awssolutions/cdf-assetlibrary/main_2023-10-06-06-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@awssolutions/cdf-assetlibrary",
+      "comment": "Change connection life cycle between Lambda and Neptune",
+      "type": "none"
+    }
+  ],
+  "packageName": "@awssolutions/cdf-assetlibrary"
+}

--- a/source/packages/services/assetlibrary/src/@types/gremlin/index.d.ts
+++ b/source/packages/services/assetlibrary/src/@types/gremlin/index.d.ts
@@ -414,7 +414,10 @@ declare module 'gremlin' {
         export class RemoteStrategy extends process.TraversalStrategy {}
 
         export class DriverRemoteConnection extends RemoteConnection {
+            open(): Promise<void>;
             close(): Promise<void>;
+            addListener(event: string | symbol, handler: (...args: any[]) => void): void;
+            removeListener(event: string | symbol, handler: (...args: any[]) => void): void;
         }
     }
 }

--- a/source/packages/services/assetlibrary/src/data/common.full.dao.ts
+++ b/source/packages/services/assetlibrary/src/data/common.full.dao.ts
@@ -146,26 +146,21 @@ export class CommonDaoFull extends BaseDaoFull {
         relatedUnion.range(offsetAsInt, offsetAsInt + countAsInt);
 
         // build the main part of the query, unioning the related traversers with the main entity we want to return
-        let results;
-        const conn = super.getConnection();
-        try {
-            const traverser = conn.traversal
-                .V(entityDbId)
-                .as('main')
-                .union(
-                    relatedUnion,
-                    __.select('main').valueMap().with_(process.withOptions.tokens)
-                );
-
-            // execute and retrieve the results
-            logger.debug(
-                `common.full.dao listRelated: traverser: ${JSON.stringify(traverser.toString())}`
+        const conn = await super.getConnection();
+        const traverser = conn.traversal
+            .V(entityDbId)
+            .as('main')
+            .union(
+                relatedUnion,
+                __.select('main').valueMap().with_(process.withOptions.tokens)
             );
-            results = await traverser.toList();
-            logger.debug(`common.full.dao listRelated: results: ${JSON.stringify(results)}`);
-        } finally {
-            await conn.close();
-        }
+
+        // execute and retrieve the results
+        logger.debug(
+            `common.full.dao listRelated: traverser: ${JSON.stringify(traverser.toString())}`
+        );
+        const results = await traverser.toList();
+        logger.debug(`common.full.dao listRelated: results: ${JSON.stringify(results)}`);
 
         if (results === undefined || results.length === 0) {
             logger.debug(`common.full.dao listRelated: exit: node: undefined`);
@@ -193,20 +188,15 @@ export class CommonDaoFull extends BaseDaoFull {
             return {};
         }
 
-        let results;
-        const conn = super.getConnection();
-        try {
-            const query = conn.traversal
-                .V(entityDbIds)
-                .project('id', 'labels')
-                .by(__.coalesce(__.values('deviceId'), __.values('groupPath')))
-                .by(__.label().fold());
+        const conn = await super.getConnection();
+        const query = conn.traversal
+            .V(entityDbIds)
+            .project('id', 'labels')
+            .by(__.coalesce(__.values('deviceId'), __.values('groupPath')))
+            .by(__.label().fold());
 
-            logger.silly(`common.full.dao getLabels: query: ${JSON.stringify(query)}`);
-            results = await query.toList();
-        } finally {
-            await conn.close();
-        }
+        logger.silly(`common.full.dao getLabels: query: ${JSON.stringify(query)}`);
+        const results = await query.toList();
         logger.silly(`common.full.dao getLabels: results: ${JSON.stringify(results)}`);
 
         if ((results?.length ?? 0) === 0) {

--- a/source/packages/services/assetlibrary/src/devices/devices.full.dao.ts
+++ b/source/packages/services/assetlibrary/src/devices/devices.full.dao.ts
@@ -200,26 +200,21 @@ export class DevicesDaoFull extends BaseDaoFull {
                       .with_(process.withOptions.tokens);
 
         // build the main part of the query, unioning the related traversers with the main entity we want to return
-        let results: process.Traverser[];
-        const conn = super.getConnection();
-        try {
-            const traverser = conn.traversal
-                .V(dbIds)
-                .as('devices')
-                .values('deviceId')
-                .as('entityId')
-                .select('devices')
-                .union(relatedIn, relatedOut, deviceProps);
+        const conn = await super.getConnection();
+        const traverser = conn.traversal
+            .V(dbIds)
+            .as('devices')
+            .values('deviceId')
+            .as('entityId')
+            .select('devices')
+            .union(relatedIn, relatedOut, deviceProps);
 
-            // execute and retrieve the results
-            logger.debug(
-                `common.full.dao listRelated: traverser: ${JSON.stringify(traverser.toString())}`
-            );
-            results = await traverser.toList();
-            logger.debug(`common.full.dao listRelated: results: ${JSON.stringify(results)}`);
-        } finally {
-            await conn.close();
-        }
+        // execute and retrieve the results
+        logger.debug(
+            `common.full.dao listRelated: traverser: ${JSON.stringify(traverser.toString())}`
+        );
+        const results = await traverser.toList();
+        logger.debug(`common.full.dao listRelated: results: ${JSON.stringify(results)}`);
 
         if ((results?.length ?? 0) === 0) {
             logger.debug(`device.full.dao get: exit: node: undefined`);
@@ -280,48 +275,44 @@ export class DevicesDaoFull extends BaseDaoFull {
         const labels = n.types.join('::');
 
         /*  create the device  */
-        const conn = super.getConnection();
-        try {
-            const traversal = conn.traversal.addV(labels).property(process.t.id, id);
+        const conn = await super.getConnection();
+        const traversal = conn.traversal.addV(labels).property(process.t.id, id);
 
-            /*  set all the device properties  */
-            for (const key of Object.keys(n.attributes)) {
-                if (n.attributes[key] !== undefined) {
-                    traversal.property(process.cardinality.single, key, n.attributes[key]);
-                }
+        /*  set all the device properties  */
+        for (const key of Object.keys(n.attributes)) {
+            if (n.attributes[key] !== undefined) {
+                traversal.property(process.cardinality.single, key, n.attributes[key]);
             }
-            traversal.as('device');
-
-            /* associate device with the related devices and/or groups */
-            associateRels(traversal, groups?.in, 'group', 'in');
-            associateRels(traversal, groups?.out, 'group', 'out');
-            associateRels(traversal, devices?.in, 'device', 'in');
-            associateRels(traversal, devices?.out, 'device', 'out');
-
-            /*  create the components  */
-            if (components) {
-                components.forEach((c) => {
-                    const componentId = c.attributes['deviceId'] as string;
-                    const componentDbId = `${id}___${componentId}`;
-                    const componentLabels = c.types.join('::');
-
-                    traversal.addV(componentLabels).property(process.t.id, componentDbId);
-
-                    for (const key of Object.keys(c.attributes)) {
-                        if (c.attributes[key] !== undefined) {
-                            traversal.property(process.cardinality.single, key, c.attributes[key]);
-                        }
-                    }
-
-                    traversal.as(componentId).addE('component_of').from_(componentId).to('device');
-                });
-            }
-
-            logger.debug(`devices.full.dao create: traversal:${traversal}`);
-            await traversal.iterate();
-        } finally {
-            await conn.close();
         }
+        traversal.as('device');
+
+        /* associate device with the related devices and/or groups */
+        associateRels(traversal, groups?.in, 'group', 'in');
+        associateRels(traversal, groups?.out, 'group', 'out');
+        associateRels(traversal, devices?.in, 'device', 'in');
+        associateRels(traversal, devices?.out, 'device', 'out');
+
+        /*  create the components  */
+        if (components) {
+            components.forEach((c) => {
+                const componentId = c.attributes['deviceId'] as string;
+                const componentDbId = `${id}___${componentId}`;
+                const componentLabels = c.types.join('::');
+
+                traversal.addV(componentLabels).property(process.t.id, componentDbId);
+
+                for (const key of Object.keys(c.attributes)) {
+                    if (c.attributes[key] !== undefined) {
+                        traversal.property(process.cardinality.single, key, c.attributes[key]);
+                    }
+                }
+
+                traversal.as(componentId).addE('component_of').from_(componentId).to('device');
+            });
+        }
+
+        logger.debug(`devices.full.dao create: traversal:${traversal}`);
+        await traversal.iterate();
 
         logger.debug(`devices.full.dao create: exit: id:${id}`);
         return id;
@@ -337,28 +328,24 @@ export class DevicesDaoFull extends BaseDaoFull {
         const labels = n.types.join('::');
 
         /*  create the component  */
-        const conn = super.getConnection();
-        try {
-            const traversal = conn.traversal.addV(labels).property(process.t.id, componentId);
+        const conn = await super.getConnection();
+        const traversal = conn.traversal.addV(labels).property(process.t.id, componentId);
 
-            for (const key of Object.keys(n.attributes)) {
-                if (n.attributes[key] !== undefined) {
-                    traversal.property(process.cardinality.single, key, n.attributes[key]);
-                }
+        for (const key of Object.keys(n.attributes)) {
+            if (n.attributes[key] !== undefined) {
+                traversal.property(process.cardinality.single, key, n.attributes[key]);
             }
-            traversal.as('component');
-
-            /*  add to the parent device  */
-            traversal.V(id).as('device').addE('component_of').from_('component').to('device');
-
-            /* for simplification, always add isAuthCheck from the component to the device, regardless fo whether used or not */
-            traversal.property(process.cardinality.single, 'isAuthCheck', true);
-
-            logger.debug(`devices.full.dao createComponent: traversal:${traversal}`);
-            await traversal.iterate();
-        } finally {
-            await conn.close();
         }
+        traversal.as('component');
+
+        /*  add to the parent device  */
+        traversal.V(id).as('device').addE('component_of').from_('component').to('device');
+
+        /* for simplification, always add isAuthCheck from the component to the device, regardless fo whether used or not */
+        traversal.property(process.cardinality.single, 'isAuthCheck', true);
+
+        logger.debug(`devices.full.dao createComponent: traversal:${traversal}`);
+        await traversal.iterate();
 
         logger.debug(`devices.full.dao createComponent: exit: componentId:${componentId}`);
         return componentId;
@@ -373,126 +360,122 @@ export class DevicesDaoFull extends BaseDaoFull {
 
         const id = `device___${n.attributes['deviceId']}`;
 
-        const conn = super.getConnection();
-        try {
-            const traversal = conn.traversal.V(id).as('device');
-            // drop() step terminates a traversal, process all drops as part of a final union step
-            const dropTraversals: process.GraphTraversal[] = [];
+        const conn = await super.getConnection();
+        const traversal = conn.traversal.V(id).as('device');
+        // drop() step terminates a traversal, process all drops as part of a final union step
+        const dropTraversals: process.GraphTraversal[] = [];
 
-            for (const [key, val] of Object.entries(n.attributes)) {
-                if (val !== undefined) {
-                    if (val === null) {
-                        dropTraversals.push(__.properties(key));
-                    } else {
-                        traversal.property(process.cardinality.single, key, val);
-                    }
+        for (const [key, val] of Object.entries(n.attributes)) {
+            if (val !== undefined) {
+                if (val === null) {
+                    dropTraversals.push(__.properties(key));
+                } else {
+                    traversal.property(process.cardinality.single, key, val);
                 }
             }
-
-            // Check if related groups or devices part of update request
-            if (groups !== undefined && (groups.in || groups.out || devices.in || devices.out)) {
-                // Update request contains relationships to enforce. This requires current
-                // relationships be dropped where specified and new relations created.
-                logger.info(
-                    `devices.full.dao update groups/devices relations specified as part of update: ${JSON.stringify(
-                        { groups: groups }
-                    )}/${JSON.stringify({ devices: devices })}`
-                );
-                const result = await this.get([`${n.attributes['deviceId']}`], false, [], false);
-                let currentDevice: DeviceItem;
-                if (result !== undefined && result.length > 0) {
-                    currentDevice = this.devicesAssembler.toDeviceItem(result[0]);
-                }
-                const existingGroups = currentDevice.groups ? currentDevice.groups : {};
-                const existingDevices = currentDevice.devices ? currentDevice.devices : {};
-                logger.debug(`Current device defintion: ${JSON.stringify(currentDevice)}`);
-                // Methodology
-                // 1. Collect relations to be dropped as independent traversal objects via diassociateRels
-                // 2. Union and then drop() these with traversal.sideEffect(...)
-                //    -- Use of sideEffect acts on the traversal then passes results to next step. Without this, a drop() will terminate traversal.
-                // 3. Add specified relations for groups and devices directly to traversal in associateRels
-                const relationsToDropTraversals: process.GraphTraversal[] = [];
-                if (groups.in && 'in' in existingGroups) {
-                    logger.debug(
-                        `devices.full.dao update device ${id} dropping existing relations for groups.in: ${JSON.stringify(
-                            existingGroups.in
-                        )}`
-                    );
-                    diassociateRels(relationsToDropTraversals, existingGroups.in, 'group', 'in');
-                }
-                if (groups.out && 'out' in existingGroups) {
-                    logger.debug(
-                        `devices.full.dao update device ${id} dropping existing relations for groups.out: ${JSON.stringify(
-                            existingGroups.out
-                        )}`
-                    );
-                    diassociateRels(relationsToDropTraversals, existingGroups.out, 'group', 'out');
-                }
-                if (devices.in && 'in' in existingDevices) {
-                    logger.debug(
-                        `devices.full.dao update device ${id} dropping existing relations for devices.in: ${JSON.stringify(
-                            existingDevices.in
-                        )}`
-                    );
-                    diassociateRels(relationsToDropTraversals, existingDevices.in, 'device', 'in');
-                }
-                if (devices.out && 'out' in existingDevices) {
-                    logger.debug(
-                        `devices.full.dao update device ${id} dropping existing relations for devices.out:: ${JSON.stringify(
-                            existingDevices.out
-                        )}`
-                    );
-                    diassociateRels(
-                        relationsToDropTraversals,
-                        existingDevices.out,
-                        'device',
-                        'out'
-                    );
-                }
-                traversal.sideEffect(__.union(...relationsToDropTraversals).drop());
-                if (groups.in) {
-                    logger.debug(
-                        `devices.full.dao update device ${id} adding relations for groups.in: ${JSON.stringify(
-                            groups.in
-                        )}`
-                    );
-                    associateRels(traversal, groups.in, 'group', 'in');
-                }
-                if (groups.out) {
-                    logger.debug(
-                        `devices.full.dao update device ${id} adding relations for groups.out: ${JSON.stringify(
-                            groups.out
-                        )}`
-                    );
-                    associateRels(traversal, groups.out, 'group', 'out');
-                }
-                if (devices.in) {
-                    logger.debug(
-                        `devices.full.dao update device ${id} adding relations for devices.in: ${JSON.stringify(
-                            devices.in
-                        )}`
-                    );
-                    associateRels(traversal, devices.in, 'device', 'in');
-                }
-                if (devices.out) {
-                    logger.debug(
-                        `devices.full.dao update device ${id} adding relations for devices.out: ${JSON.stringify(
-                            devices.out
-                        )}`
-                    );
-                    associateRels(traversal, devices.out, 'device', 'out');
-                }
-            }
-            if (dropTraversals.length > 0) {
-                traversal.local(__.union(...dropTraversals)).drop();
-            }
-            logger.debug(
-                `devices.full.dao update traversal before iterate is: ${JSON.stringify(traversal)}`
-            );
-            await traversal.iterate();
-        } finally {
-            await conn.close();
         }
+
+        // Check if related groups or devices part of update request
+        if (groups !== undefined && (groups.in || groups.out || devices.in || devices.out)) {
+            // Update request contains relationships to enforce. This requires current
+            // relationships be dropped where specified and new relations created.
+            logger.info(
+                `devices.full.dao update groups/devices relations specified as part of update: ${JSON.stringify(
+                    { groups: groups }
+                )}/${JSON.stringify({ devices: devices })}`
+            );
+            const result = await this.get([`${n.attributes['deviceId']}`], false, [], false);
+            let currentDevice: DeviceItem;
+            if (result !== undefined && result.length > 0) {
+                currentDevice = this.devicesAssembler.toDeviceItem(result[0]);
+            }
+            const existingGroups = currentDevice.groups ? currentDevice.groups : {};
+            const existingDevices = currentDevice.devices ? currentDevice.devices : {};
+            logger.debug(`Current device defintion: ${JSON.stringify(currentDevice)}`);
+            // Methodology
+            // 1. Collect relations to be dropped as independent traversal objects via diassociateRels
+            // 2. Union and then drop() these with traversal.sideEffect(...)
+            //    -- Use of sideEffect acts on the traversal then passes results to next step. Without this, a drop() will terminate traversal.
+            // 3. Add specified relations for groups and devices directly to traversal in associateRels
+            const relationsToDropTraversals: process.GraphTraversal[] = [];
+            if (groups.in && 'in' in existingGroups) {
+                logger.debug(
+                    `devices.full.dao update device ${id} dropping existing relations for groups.in: ${JSON.stringify(
+                        existingGroups.in
+                    )}`
+                );
+                diassociateRels(relationsToDropTraversals, existingGroups.in, 'group', 'in');
+            }
+            if (groups.out && 'out' in existingGroups) {
+                logger.debug(
+                    `devices.full.dao update device ${id} dropping existing relations for groups.out: ${JSON.stringify(
+                        existingGroups.out
+                    )}`
+                );
+                diassociateRels(relationsToDropTraversals, existingGroups.out, 'group', 'out');
+            }
+            if (devices.in && 'in' in existingDevices) {
+                logger.debug(
+                    `devices.full.dao update device ${id} dropping existing relations for devices.in: ${JSON.stringify(
+                        existingDevices.in
+                    )}`
+                );
+                diassociateRels(relationsToDropTraversals, existingDevices.in, 'device', 'in');
+            }
+            if (devices.out && 'out' in existingDevices) {
+                logger.debug(
+                    `devices.full.dao update device ${id} dropping existing relations for devices.out:: ${JSON.stringify(
+                        existingDevices.out
+                    )}`
+                );
+                diassociateRels(
+                    relationsToDropTraversals,
+                    existingDevices.out,
+                    'device',
+                    'out'
+                );
+            }
+            traversal.sideEffect(__.union(...relationsToDropTraversals).drop());
+            if (groups.in) {
+                logger.debug(
+                    `devices.full.dao update device ${id} adding relations for groups.in: ${JSON.stringify(
+                        groups.in
+                    )}`
+                );
+                associateRels(traversal, groups.in, 'group', 'in');
+            }
+            if (groups.out) {
+                logger.debug(
+                    `devices.full.dao update device ${id} adding relations for groups.out: ${JSON.stringify(
+                        groups.out
+                    )}`
+                );
+                associateRels(traversal, groups.out, 'group', 'out');
+            }
+            if (devices.in) {
+                logger.debug(
+                    `devices.full.dao update device ${id} adding relations for devices.in: ${JSON.stringify(
+                        devices.in
+                    )}`
+                );
+                associateRels(traversal, devices.in, 'device', 'in');
+            }
+            if (devices.out) {
+                logger.debug(
+                    `devices.full.dao update device ${id} adding relations for devices.out: ${JSON.stringify(
+                        devices.out
+                    )}`
+                );
+                associateRels(traversal, devices.out, 'device', 'out');
+            }
+        }
+        if (dropTraversals.length > 0) {
+            traversal.local(__.union(...dropTraversals)).drop();
+        }
+        logger.debug(
+            `devices.full.dao update traversal before iterate is: ${JSON.stringify(traversal)}`
+        );
+        await traversal.iterate();
         logger.debug(`devices.full.dao update: exit:`);
     }
 
@@ -501,12 +484,8 @@ export class DevicesDaoFull extends BaseDaoFull {
 
         const id = `device___${deviceId}`;
 
-        const conn = super.getConnection();
-        try {
-            await conn.traversal.V(id).drop().iterate();
-        } finally {
-            await conn.close();
-        }
+        const conn = await super.getConnection();
+        await conn.traversal.V(id).drop().iterate();
 
         logger.debug(`devices.full.dao delete: exit`);
     }
@@ -533,26 +512,22 @@ export class DevicesDaoFull extends BaseDaoFull {
             targetId = `device___${deviceId}`;
         }
 
-        const conn = super.getConnection();
-        try {
-            const traverser = conn.traversal
-                .V(targetId)
-                .as('target')
-                .V(sourceId)
-                .as('source')
-                .addE(relationship)
-                .to('target');
+        const conn = await super.getConnection();
+        const traverser = conn.traversal
+            .V(targetId)
+            .as('target')
+            .V(sourceId)
+            .as('source')
+            .addE(relationship)
+            .to('target');
 
-            if (isAuthCheck) {
-                traverser.property(process.cardinality.single, 'isAuthCheck', true);
-            }
-
-            const result = await traverser.iterate();
-
-            logger.debug(`devices.full.dao attachToGroup: result:${JSON.stringify(result)}`);
-        } finally {
-            await conn.close();
+        if (isAuthCheck) {
+            traverser.property(process.cardinality.single, 'isAuthCheck', true);
         }
+
+        const result = await traverser.iterate();
+
+        logger.debug(`devices.full.dao attachToGroup: result:${JSON.stringify(result)}`);
 
         logger.debug(`devices.full.dao attachToGroup: exit:`);
     }
@@ -596,24 +571,20 @@ export class DevicesDaoFull extends BaseDaoFull {
         const sourceId = `device___${source}`;
         const targetId = `device___${target}`;
 
-        const conn = super.getConnection();
-        try {
-            const traverser = conn.traversal
-                .V(targetId)
-                .as('other')
-                .V(sourceId)
-                .addE(relationship)
-                .to('other');
+        const conn = await super.getConnection();
+        const traverser = conn.traversal
+            .V(targetId)
+            .as('other')
+            .V(sourceId)
+            .addE(relationship)
+            .to('other');
 
-            if (isAuthCheck) {
-                traverser.property(process.cardinality.single, 'isAuthCheck', true);
-            }
-
-            const result = await traverser.iterate();
-            logger.debug(`devices.full.dao attachToDevice: result:${JSON.stringify(result)}`);
-        } finally {
-            await conn.close();
+        if (isAuthCheck) {
+            traverser.property(process.cardinality.single, 'isAuthCheck', true);
         }
+
+        const result = await traverser.iterate();
+        logger.debug(`devices.full.dao attachToDevice: result:${JSON.stringify(result)}`);
 
         logger.debug(`devices.full.dao attachToDevice: exit:`);
     }
@@ -671,17 +642,13 @@ export class DevicesDaoFull extends BaseDaoFull {
             edgesToDelete.push(t);
         }
 
-        const conn = super.getConnection();
-        try {
-            await conn.traversal
-                .V(`device___${deviceId}`)
-                .as('source')
-                .union(...edgesToDelete)
-                .drop()
-                .iterate();
-        } finally {
-            await conn.close();
-        }
+        const conn = await super.getConnection();
+        await conn.traversal
+            .V(`device___${deviceId}`)
+            .as('source')
+            .union(...edgesToDelete)
+            .drop()
+            .iterate();
 
         logger.debug(`devices.full.dao detachFromOthers: exit:`);
     }

--- a/source/packages/services/assetlibrary/src/policies/policies.full.dao.ts
+++ b/source/packages/services/assetlibrary/src/policies/policies.full.dao.ts
@@ -33,19 +33,14 @@ export class PoliciesDaoFull extends BaseDaoFull {
 
         const id = `policy___${policyId.toLowerCase()}`;
 
-        let query;
-        const conn = super.getConnection();
-        try {
-            query = await conn.traversal
-                .V(id)
-                .as('policy')
-                .project('policy', 'groups')
-                .by(__.select('policy').valueMap().with_(process.withOptions.tokens))
-                .by(__.select('policy').out('appliesTo').hasLabel('group').fold())
-                .next();
-        } finally {
-            await conn.close();
-        }
+        const conn = await super.getConnection();
+        const query = await conn.traversal
+            .V(id)
+            .as('policy')
+            .project('policy', 'groups')
+            .by(__.select('policy').valueMap().with_(process.withOptions.tokens))
+            .by(__.select('policy').out('appliesTo').hasLabel('group').fold())
+            .next();
 
         logger.debug(`policy.full.dao get: query: ${JSON.stringify(query)}`);
 
@@ -64,25 +59,21 @@ export class PoliciesDaoFull extends BaseDaoFull {
 
         const id = `policy___${model.policyId.toLowerCase()}`;
 
-        const conn = super.getConnection();
-        try {
-            const traversal = conn.traversal
-                .addV('policy')
-                .property(process.t.id, id)
-                .property('policyId', model.policyId.toLowerCase())
-                .property('type', model.type)
-                .property('description', model.description)
-                .property('document', model.document)
-                .as('policy');
+        const conn = await super.getConnection();
+        const traversal = conn.traversal
+            .addV('policy')
+            .property(process.t.id, id)
+            .property('policyId', model.policyId.toLowerCase())
+            .property('type', model.type)
+            .property('description', model.description)
+            .property('document', model.document)
+            .as('policy');
 
-            model.appliesTo.forEach((path, index) => {
-                this.addCreateAppliesToTraversal(path, index, traversal);
-            });
+        model.appliesTo.forEach((path, index) => {
+            this.addCreateAppliesToTraversal(path, index, traversal);
+        });
 
-            await traversal.iterate();
-        } finally {
-            await conn.close();
-        }
+        await traversal.iterate();
 
         logger.debug(`policies.dao create: exit: id: ${id}`);
         return id;
@@ -113,50 +104,46 @@ export class PoliciesDaoFull extends BaseDaoFull {
         const id = `policy___${existing.policyId}`;
 
         /*  update the main policy object  */
-        const conn = super.getConnection();
-        try {
-            const traversal = conn.traversal.V(id);
+        const conn = await super.getConnection();
+        const traversal = conn.traversal.V(id);
 
-            if (updated.type) {
-                traversal.property(process.cardinality.single, 'type', updated.type.toLowerCase());
-            }
-            if (updated.description) {
-                traversal.property(process.cardinality.single, 'description', updated.description);
-            }
-            if (updated.document) {
-                traversal.property(process.cardinality.single, 'document', updated.document);
-            }
-            traversal.as('policy');
-
-            /*  identfy any changes in the appliesTo relationship  */
-            const changedAppliesTo = this.identifyChangedAppliesTo(
-                existing.appliesTo,
-                updated.appliesTo
-            );
-            logger.debug(
-                `policies.dao update: changedAppliesTo: ${JSON.stringify(changedAppliesTo)}`
-            );
-
-            /*  any new appliesTo we can simply add the step to the traversal  */
-            changedAppliesTo.add.forEach((path, index) => {
-                this.addCreateAppliesToTraversal(path, index, traversal);
-            });
-
-            /*  as a drop() step terminates a traversal, we need to process all these as part of a single union step as the last step  */
-            const removedAppliesToSteps: process.GraphTraversal[] = [];
-            changedAppliesTo.remove.forEach((path) => {
-                removedAppliesToSteps.push(this.addRemoveAppliesToTraversal(path));
-            });
-            if (removedAppliesToSteps.length > 0) {
-                traversal.local(__.union(...removedAppliesToSteps)).drop();
-            }
-
-            /*  lets execute it  */
-            const query = await traversal.iterate();
-            logger.debug(`policies.dao update: query: ${JSON.stringify(query)}`);
-        } finally {
-            await conn.close();
+        if (updated.type) {
+            traversal.property(process.cardinality.single, 'type', updated.type.toLowerCase());
         }
+        if (updated.description) {
+            traversal.property(process.cardinality.single, 'description', updated.description);
+        }
+        if (updated.document) {
+            traversal.property(process.cardinality.single, 'document', updated.document);
+        }
+        traversal.as('policy');
+
+        /*  identfy any changes in the appliesTo relationship  */
+        const changedAppliesTo = this.identifyChangedAppliesTo(
+            existing.appliesTo,
+            updated.appliesTo
+        );
+        logger.debug(
+            `policies.dao update: changedAppliesTo: ${JSON.stringify(changedAppliesTo)}`
+        );
+
+        /*  any new appliesTo we can simply add the step to the traversal  */
+        changedAppliesTo.add.forEach((path, index) => {
+            this.addCreateAppliesToTraversal(path, index, traversal);
+        });
+
+        /*  as a drop() step terminates a traversal, we need to process all these as part of a single union step as the last step  */
+        const removedAppliesToSteps: process.GraphTraversal[] = [];
+        changedAppliesTo.remove.forEach((path) => {
+            removedAppliesToSteps.push(this.addRemoveAppliesToTraversal(path));
+        });
+        if (removedAppliesToSteps.length > 0) {
+            traversal.local(__.union(...removedAppliesToSteps)).drop();
+        }
+
+        /*  lets execute it  */
+        const query = await traversal.iterate();
+        logger.debug(`policies.dao update: query: ${JSON.stringify(query)}`);
 
         logger.debug(`policies.dao update: exit: id: ${id}`);
         return id;
@@ -196,27 +183,22 @@ export class PoliciesDaoFull extends BaseDaoFull {
 
         const id = `device___${deviceId.toLowerCase()}`;
 
-        let results;
-        const conn = super.getConnection();
-        try {
-            results = await conn.traversal
-                .V(id)
-                .as('device')
-                .union(__.out(), __.out().repeat(__.out('parent').simplePath().dedup()).emit())
-                .as('deviceGroups')
-                .in_('appliesTo')
-                .hasLabel('policy')
-                .has('type', type)
-                .dedup()
-                .as('policies')
-                .project('policy', 'groups', 'policyGroups')
-                .by(__.identity().valueMap().with_(process.withOptions.tokens))
-                .by(__.select('device').out().hasLabel('group').fold())
-                .by(__.local(__.out('appliesTo').fold()))
-                .toList();
-        } finally {
-            await conn.close();
-        }
+        const conn = await super.getConnection();
+        const results = await conn.traversal
+            .V(id)
+            .as('device')
+            .union(__.out(), __.out().repeat(__.out('parent').simplePath().dedup()).emit())
+            .as('deviceGroups')
+            .in_('appliesTo')
+            .hasLabel('policy')
+            .has('type', type)
+            .dedup()
+            .as('policies')
+            .project('policy', 'groups', 'policyGroups')
+            .by(__.identity().valueMap().with_(process.withOptions.tokens))
+            .by(__.select('device').out().hasLabel('group').fold())
+            .by(__.local(__.out('appliesTo').fold()))
+            .toList();
 
         const policies: AttachedPolicy[] = [];
         for (const result of results) {
@@ -240,33 +222,28 @@ export class PoliciesDaoFull extends BaseDaoFull {
         const ids: string[] = [];
         groupPaths.forEach((v) => ids.push(`group___${v.toLowerCase()}`));
 
-        let results;
-        const conn = super.getConnection();
-        try {
-            const traverser = conn.traversal
-                .V(ids)
-                .as('groups')
-                .union(__.identity(), __.repeat(__.out('parent').simplePath().dedup()).emit())
-                .as('parentGroups')
-                .in_('appliesTo')
-                .hasLabel('policy');
+        const conn = await super.getConnection();
+        const traverser = conn.traversal
+            .V(ids)
+            .as('groups')
+            .union(__.identity(), __.repeat(__.out('parent').simplePath().dedup()).emit())
+            .as('parentGroups')
+            .in_('appliesTo')
+            .hasLabel('policy');
 
-            if (type !== undefined) {
-                traverser.has('type', type);
-            }
-
-            traverser
-                .dedup()
-                .as('policies')
-                .project('policy', 'groups', 'policyGroups')
-                .by(__.identity().valueMap().with_(process.withOptions.tokens))
-                .by(__.select('groups').fold())
-                .by(__.local(__.out('appliesTo').fold()));
-
-            results = await traverser.toList();
-        } finally {
-            await conn.close();
+        if (type !== undefined) {
+            traverser.has('type', type);
         }
+
+        traverser
+            .dedup()
+            .as('policies')
+            .project('policy', 'groups', 'policyGroups')
+            .by(__.identity().valueMap().with_(process.withOptions.tokens))
+            .by(__.select('groups').fold())
+            .by(__.local(__.out('appliesTo').fold()));
+
+        const results = await traverser.toList();
 
         const policies: AttachedPolicy[] = [];
         for (const result of results) {
@@ -282,32 +259,27 @@ export class PoliciesDaoFull extends BaseDaoFull {
     public async listPolicies(type: string, offset: number, count: number): Promise<Policy[]> {
         logger.debug(`policies.dao listPolicies: type:${type}, offset:${offset}, count:${count}`);
 
-        let results;
-        const conn = super.getConnection();
-        try {
-            const traverser = conn.traversal.V().hasLabel('policy');
-            if (type !== undefined) {
-                traverser.has('type', type.toLowerCase());
-            }
-            traverser
-                .as('policies')
-                .project('policy', 'groups')
-                .by(__.valueMap().with_(process.withOptions.tokens))
-                .by(__.out('appliesTo').hasLabel('group').fold());
-
-            // apply pagination
-            if (offset !== undefined && count !== undefined) {
-                // note: workaround for wierd typescript issue. even though offset/count are declared as numbers
-                // througout, they are being interpreted as strings within gremlin, therefore need to force to int beforehand
-                const offsetAsInt = parseInt(offset.toString(), 0);
-                const countAsInt = parseInt(count.toString(), 0);
-                traverser.range(offsetAsInt, offsetAsInt + countAsInt);
-            }
-
-            results = await traverser.toList();
-        } finally {
-            await conn.close();
+        const conn = await super.getConnection();
+        const traverser = conn.traversal.V().hasLabel('policy');
+        if (type !== undefined) {
+            traverser.has('type', type.toLowerCase());
         }
+        traverser
+            .as('policies')
+            .project('policy', 'groups')
+            .by(__.valueMap().with_(process.withOptions.tokens))
+            .by(__.out('appliesTo').hasLabel('group').fold());
+
+        // apply pagination
+        if (offset !== undefined && count !== undefined) {
+            // note: workaround for wierd typescript issue. even though offset/count are declared as numbers
+            // througout, they are being interpreted as strings within gremlin, therefore need to force to int beforehand
+            const offsetAsInt = parseInt(offset.toString(), 0);
+            const countAsInt = parseInt(count.toString(), 0);
+            traverser.range(offsetAsInt, offsetAsInt + countAsInt);
+        }
+
+        const results = await traverser.toList();
 
         logger.debug(`results: ${JSON.stringify(results)}`);
 
@@ -325,12 +297,8 @@ export class PoliciesDaoFull extends BaseDaoFull {
 
         const dbId = `policy___${policyId.toLowerCase()}`;
 
-        const conn = super.getConnection();
-        try {
-            await conn.traversal.V(dbId).drop().next();
-        } finally {
-            await conn.close();
-        }
+        const conn = await super.getConnection();
+        await conn.traversal.V(dbId).drop().next();
 
         logger.debug(`policies.dao delete: exit`);
     }


### PR DESCRIPTION
# Description
<!-- Briefly describe noteworthy details -->

Modified Asset Library Lambda function to use a single connection between Lambda function and Neptune throughout the Lambda lifecycle.

According to [Neptune’s documentation](https://docs.aws.amazon.com/neptune/latest/userguide/lambda-functions.html#lambda-functions-gremlin-recommendations), when accessing Neptune from Lambda, it is recommended to create one connection through the Lambda lifecycle and reuse it between invocations.
Opening and closing a Neptune connection per query causes performance issues in a state of high throughput.

## Type of change

- [x] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change includes a documentation update*

# Submission Checklist

- [x] CI dry-run passing
- [x] Integration tests passing locally
- [x] Change logs generated 

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->

I think it would be nice to have a mechanism to retry when there is an error. Now AssetLibrary users need to check the details of the error and decide if it can retry or not.