### PR TITLE
Command and Control integ test fix

### DIFF
--- a/source/packages/integration-tests/features/commandandcontrol/jobs.feature
+++ b/source/packages/integration-tests/features/commandandcontrol/jobs.feature
@@ -87,7 +87,9 @@ Feature: Command & Control - Jobs
       | $.status                              | awaiting_replies                                                       |
       | $.createdAt                           | ___regex___:^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).(\d{3})Z$ |
       | $.updatedAt                           | ___regex___:^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).(\d{3})Z$ |
-    When I pause for 3000ms
+    # TODO: Discover why this message has a 30second delay, which necessitates this 30sec pause
+    # https://github.com/aws/aws-connected-device-framework/blob/main/source/packages/services/command-and-control/src/messages/workflow/workflow.createEphemeralGroup.ts#L190
+    When I pause for 30000ms
     Then last command-and-control message has recipients:
       | $.recipients.length            | 2                                     |
       | $.recipients.[0].id            | cdf-integration-test-cac-jobs-device1 |

--- a/source/packages/integration-tests/src/step_definitions/commandandcontrol/replies.steps.ts
+++ b/source/packages/integration-tests/src/step_definitions/commandandcontrol/replies.steps.ts
@@ -12,29 +12,29 @@
  *********************************************************************************************************************/
 import 'reflect-metadata';
 
-import { use } from 'chai';
-import { setDefaultTimeout, DataTable, Then, When } from '@cucumber/cucumber';
+import { DataTable, Then, When, setDefaultTimeout } from '@cucumber/cucumber';
 import axios from 'axios';
+import { use } from 'chai';
 
-import { container } from '../../di/inversify.config';
 import {
     COMMANDANDCONTROL_CLIENT_TYPES,
     MessagesService,
 } from '@awssolutions/cdf-commandandcontrol-client';
+import { container } from '../../di/inversify.config';
 
-import { iot, mqtt, iotshadow, iotjobs } from 'aws-iot-device-sdk-v2';
-
-import chai_string = require('chai-string');
-import { world } from './commandandcontrol.world';
-import {
-    getAdditionalHeaders,
-    validateExpectedAttributes,
-    buildModel,
-} from '../common/common.steps';
 import { fail } from 'assert';
-import { JobsTestClient } from './jobsTestClient';
+import { iot, iotjobs, iotshadow, mqtt } from 'aws-iot-device-sdk-v2';
 import fs from 'fs';
 import os from 'os';
+import {
+    buildModel,
+    getAdditionalHeaders,
+    validateExpectedAttributes,
+} from '../common/common.steps';
+import { world } from './commandandcontrol.world';
+import { JobsTestClient } from './jobsTestClient';
+
+import chai_string = require('chai-string');
 import path = require('path');
 
 use(chai_string);

--- a/source/packages/integration-tests/src/step_definitions/commandandcontrol/replies.steps.ts
+++ b/source/packages/integration-tests/src/step_definitions/commandandcontrol/replies.steps.ts
@@ -153,8 +153,13 @@ async function reply(thingName: string, action: string, data?: DataTable) {
                     payload as { [key: string]: string }
                 );
             } catch (e) {
-                const { requestId, cfId, extendedRequestId } = e.$metadata;
-                console.log({ requestId, cfId, extendedRequestId });
+                if (e instanceof Error) {
+                    console.log(e.message);
+                    console.log(e.stack);
+                } else {
+                    const { requestId, cfId, extendedRequestId } = e.$metadata;
+                    console.log({ requestId, cfId, extendedRequestId });
+                }
             }
             break;
         }

--- a/source/packages/services/assetlibrary/README.md
+++ b/source/packages/services/assetlibrary/README.md
@@ -160,7 +160,7 @@ Devices:
 - `device001` associated with group `/location/usa/colorado/denver/factory1`
 - `device002` associated with group `/location/china/northern/beijing/factory2`
 
-In the example above, retrieving the list of policies for `device001` would return `policy_permissive`, whereas retrieiving the policy list for `device002` will be the chain `policy_restrictive` then `policy_permissive`, with the consuming application containing the business logic for which policy to use (e.g. use `policy_permissive` as that's associated with the lowest level group `/location/china`).
+In the example above, retrieving the list of policies for `device001` would return `policy_permissive`, whereas retrieiving the policy list for `device002` will be the chain `policy_restrictive` then `policy_permissive`, with the consuming application containing the business logic for which policy to use (e.g. use `policy_restrictive` as that's associated with the lowest level group `/location/china`).
 
 #### Scenario 2
 

--- a/source/packages/services/assetlibrary/docs/templates-user.md
+++ b/source/packages/services/assetlibrary/docs/templates-user.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-All groups and devices created within the Asset Library must confirm to a template. A template represents a custom group or device type, with a schema that defines the attributes it may contain, along with the allowed relations a group or device may have between each other.
+All groups and devices created within the Asset Library must conform to a template. A template represents a custom group or device type, with a schema that defines the attributes it may contain, along with the allowed relations a group or device may have between each other.
 
 In addition, a device can be classified as a component which is a special type of device that can only exist when it is part of a larger device assembly. A real world example could be a robotic arm that is represented as a Thing in AWS IoT, which itself is comprised of multiple sensors that are also represented as individual Things within AWS IoT.
 

--- a/source/packages/services/command-and-control/README.md
+++ b/source/packages/services/command-and-control/README.md
@@ -18,7 +18,7 @@ Refer to the [Swagger](docs/swagger.yml) for a detailed list of the available RE
 
 ## Walkthrough
 
-The following walkthroughs give examples of how to configure commands sent vis MQTT topics, via AWS IoT Device Shadows, and via AWS IoT Jobs. Even though the definition of each command is slightly different, what is important is that the way the messages are sent, the way the messages are received, the way recipients are listed, and the way replies are listed, is consistent across all three methods.
+The following walkthroughs give examples of how to configure commands sent via MQTT topics, via AWS IoT Device Shadows, and via AWS IoT Jobs. Even though the definition of each command is slightly different, what is important is that the way the messages are sent, the way the messages are received, the way recipients are listed, and the way replies are listed, is consistent across all three methods.
 
 ### Example 1: Send a reboot command to a single device via an MQTT topic
 


### PR DESCRIPTION
# Description
This fixes two issues that were causing command and control tests to fail.
One was error logging in commandandcontrol/replies.steps.ts would fail if it caught a standard error, which we throw in the [case of No Job](https://github.com/aws/aws-connected-device-framework/blob/main/source/packages/integration-tests/src/step_definitions/commandandcontrol/jobsTestClient.ts#L75).
The second was that the recent Ephemeral Group change has a [30 second delay](https://github.com/aws/aws-connected-device-framework/blob/main/source/packages/services/command-and-control/src/messages/workflow/workflow.createEphemeralGroup.ts#L190) on the SQS message it sends.

This is a temporary fix so that tests pass as expected, but we should do additional investigation and document why this 30 second delay is necessary.

Also, a couple of documentation spelling fixes.

## Type of change

- [x] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [x] *This change includes a documentation update*

# Submission Checklist

- [ ] CI dry-run passing
- [x] Integration tests passing locally
- [ ] Change logs generated 
