### PR TITLE
fix: correcting teardown for integ test and code cleanup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "editor.codeActionsOnSave": {
-        "source.organizeImports": true
+      "source.organizeImports": "explicit"
     },
     "editor.formatOnSave": true,
     "editor.formatOnPaste": true,

--- a/source/common/config/rush/pnpm-lock.yaml
+++ b/source/common/config/rush/pnpm-lock.yaml
@@ -2007,6 +2007,9 @@ importers:
         specifier: 4.4.0
         version: 4.4.0
     devDependencies:
+      '@awssolutions/cdf-config-inject':
+        specifier: workspace:^2.5.2
+        version: link:../../config/config-inject
       '@awssolutions/eslint-config-custom':
         specifier: workspace:~0.0.0
         version: link:../../config/eslint-config-custom

--- a/source/common/config/rush/repo-state.json
+++ b/source/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "a91e3cdfb0f70338c98919f90c62b3eb5bfe08c0",
+  "pnpmShrinkwrapHash": "def9633ab3e27f220d855c6f5ccdf1e7bdf6dfb9",
   "preferredVersionsHash": "14c05a7722342014cec64c4bef7d9bed0d0b7b7f"
 }

--- a/source/packages/integration-tests/features/device-patcher/patch.feature
+++ b/source/packages/integration-tests/features/device-patcher/patch.feature
@@ -39,27 +39,27 @@ Feature: Device Patching
       | $.patches[?(@.deviceId=="IntegrationTestCore1")].statusMessage        | DEVICE_ACTIVATION_NOT_FOUND                                                            |
       | $.patches[?(@.deviceId=="IntegrationTestCore1")].associationId        | null                                                                                   |
 
-  # This test disabled because it is flaky. To-be investigated
-  # Scenario: Create a patch task for an EC2 Simulated edge device
-  #   Given patch template "integration_test_template" exists
-  #   And I create an activation for "ec2_edge_device_01" edge device
-  #   When I launch an EC2 Instance "ec2_edge_device_01" emulating as an edge device
-  #   And I pause for 180000ms
-  #   When I create a patch Task for "ec2_edge_device_01" edge device with attributes
-  #     | patchTemplateName | integration_test_template                                       |
-  #     | extraVars         | { "uniqueVar1": "uniqueVarVal1", "uniqueVar2": "uniqueVarVal2"} |
-  #   And I pause for 360000ms
-  #   And last patch for device exists with following attributes
-  #     | $.patches[?(@.deviceId=="ec2_edge_device_01")].deviceId             | ec2_edge_device_01                                                                     |
-  #     | $.patches[?(@.deviceId=="ec2_edge_device_01")].patchId              | ___regex___:^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$ |
-  #     | $.patches[?(@.deviceId=="ec2_edge_device_01")].taskId               | ___regex___:^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$ |
-  #     | $.patches[?(@.deviceId=="ec2_edge_device_01")].createdAt            | ___regex___:^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).(\d{3})Z$                 |
-  #     | $.patches[?(@.deviceId=="ec2_edge_device_01")].updatedAt            | ___regex___:^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).(\d{3})Z$                 |
-  #     | $.patches[?(@.deviceId=="ec2_edge_device_01")].extraVars.uniqueVar1 | uniqueVarVal1                                                                          |
-  #     | $.patches[?(@.deviceId=="ec2_edge_device_01")].extraVars.uniqueVar2 | uniqueVarVal2                                                                          |
-  #     | $.patches[?(@.deviceId=="ec2_edge_device_01")].patchType            | agentbased                                                                             |
-  #     | $.patches[?(@.deviceId=="ec2_edge_device_01")].patchStatus          | success                                                                                |
-  #     | $.patches[?(@.deviceId=="ec2_edge_device_01")].associationId        | ___regex___:^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$ |
+  # TODO: validate this test is no longer flaky with teardown cleanup
+  Scenario: Create a patch task for an EC2 Simulated edge device
+    Given patch template "integration_test_template" exists
+    And I create an activation for "ec2_edge_device_01" edge device
+    When I launch an EC2 Instance "ec2_edge_device_01" emulating as an edge device
+    And I pause for 90000ms
+    When I create a patch Task for "ec2_edge_device_01" edge device with attributes
+      | patchTemplateName | integration_test_template                                       |
+      | extraVars         | { "uniqueVar1": "uniqueVarVal1", "uniqueVar2": "uniqueVarVal2"} |
+    And I pause for 120000ms
+    And last patch for device exists with following attributes
+      | $.patches[?(@.deviceId=="ec2_edge_device_01")].deviceId             | ec2_edge_device_01                                                                     |
+      | $.patches[?(@.deviceId=="ec2_edge_device_01")].patchId              | ___regex___:^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$ |
+      | $.patches[?(@.deviceId=="ec2_edge_device_01")].taskId               | ___regex___:^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$ |
+      | $.patches[?(@.deviceId=="ec2_edge_device_01")].createdAt            | ___regex___:^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).(\d{3})Z$                 |
+      | $.patches[?(@.deviceId=="ec2_edge_device_01")].updatedAt            | ___regex___:^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).(\d{3})Z$                 |
+      | $.patches[?(@.deviceId=="ec2_edge_device_01")].extraVars.uniqueVar1 | uniqueVarVal1                                                                          |
+      | $.patches[?(@.deviceId=="ec2_edge_device_01")].extraVars.uniqueVar2 | uniqueVarVal2                                                                          |
+      | $.patches[?(@.deviceId=="ec2_edge_device_01")].patchType            | agentbased                                                                             |
+      | $.patches[?(@.deviceId=="ec2_edge_device_01")].patchStatus          | success                                                                                |
+      | $.patches[?(@.deviceId=="ec2_edge_device_01")].associationId        | ___regex___:^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$ |
 
   @teardown_patch_features
   Scenario: Teardown

--- a/source/packages/integration-tests/src/step_definitions/commandandcontrol/messages.steps.ts
+++ b/source/packages/integration-tests/src/step_definitions/commandandcontrol/messages.steps.ts
@@ -12,18 +12,18 @@
  *********************************************************************************************************************/
 import 'reflect-metadata';
 
+import { DataTable, Then, When, setDefaultTimeout } from '@cucumber/cucumber';
 import { expect, use } from 'chai';
-import { setDefaultTimeout, DataTable, Then, When } from '@cucumber/cucumber';
 
-import { container } from '../../di/inversify.config';
-import { buildModel, validateExpectedAttributes } from '../common/common.steps';
-import { getAdditionalHeaders } from '../notifications/notifications.utils';
-import { world } from './commandandcontrol.world';
 import {
     COMMANDANDCONTROL_CLIENT_TYPES,
     MessageResource,
     MessagesService,
 } from '@awssolutions/cdf-commandandcontrol-client';
+import { container } from '../../di/inversify.config';
+import { buildModel, validateExpectedAttributes } from '../common/common.steps';
+import { getAdditionalHeaders } from '../notifications/notifications.utils';
+import { world } from './commandandcontrol.world';
 
 import chai_string = require('chai-string');
 use(chai_string);

--- a/source/packages/integration-tests/src/step_definitions/device-patcher/deployment.step.ts
+++ b/source/packages/integration-tests/src/step_definitions/device-patcher/deployment.step.ts
@@ -25,6 +25,7 @@ import {
 } from '@awssolutions/cdf-device-patcher-client';
 
 import { EC2Client, RunInstancesCommand, RunInstancesCommandInput } from '@aws-sdk/client-ec2';
+import { logger } from '@awssolutions/simple-cdf-logger';
 import { fail } from 'assert';
 import fs from 'fs';
 import { container } from '../../di/inversify.config';
@@ -102,7 +103,7 @@ When(
                 options.to = activation.activationRegion;
                 await replaceInFile(options);
             } catch (err) {
-                console.log(`preparing bootstrap script failed: ${err}`);
+                logger.error(`preparing bootstrap script failed: ${err}`);
                 throw err;
             }
 
@@ -136,7 +137,7 @@ When(
                 };
                 await ec2.send(new RunInstancesCommand(params));
             } catch (err) {
-                console.log(`launching ec2 failed: ${err}`);
+                logger.error(`launching ec2 failed: ${err}`);
                 throw err;
             }
         } catch (err) {
@@ -267,7 +268,6 @@ Then(
         const artifacts_certs_key = this['core']?.artifacts?.certs?.key;
         const artifacts_config_bucket = this['core']?.artifacts?.config?.bucket;
         const artifacts_config_key = this['core']?.artifacts?.config?.key;
-
         const patch: CreatePatchRequest = {
             deviceId,
             patchTemplateName: template,
@@ -295,6 +295,7 @@ Then(
                 patchTask,
                 getAdditionalHeaders(world.authToken)
             );
+            logger.debug('patchTaskId: ' + this['patchTaskId']);
         } catch (e) {
             this[RESPONSE_STATUS] = e.status;
         }

--- a/source/packages/integration-tests/src/support/greengrass2_provisioning_hooks.ts
+++ b/source/packages/integration-tests/src/support/greengrass2_provisioning_hooks.ts
@@ -56,16 +56,13 @@ const templateBucket = process.env.PROVISIONING_TEMPLATES_BUCKET;
 const templatePrefix = process.env.PROVISIONING_TEMPLATES_PREFIX;
 
 async function teardown(world: unknown) {
-    // logger.debug(`\ngreengrass_provisioning_hooks: teardown: in:`);
-
-    logger.debug(`\ngreengrass_provisioning_hooks: teardown: in: ${JSON.stringify(world)}`);
-
     // service cleanup
     const templates = ['IntegrationTest'];
     for (const t of templates) {
         try {
             await templatesSvc.deleteTemplate(t, getAdditionalHeaders(world[AUTHORIZATION_TOKEN]));
         } catch (err) {
+            logger.silly(`teardown: deleteTemplate: ${JSON.stringify(err)}`);
             // swallow the error
         }
     }
@@ -75,6 +72,7 @@ async function teardown(world: unknown) {
         try {
             await deviceSvc.deleteDevice(clientDevice);
         } catch (err) {
+            logger.silly(`teardown: deleteDevice: ${JSON.stringify(err)}`);
             // swallow the error
         }
     }
@@ -95,6 +93,7 @@ async function teardown(world: unknown) {
             }),
         });
     } catch (err) {
+        logger.silly(`teardown: createCoreTask: ${JSON.stringify(err)}`);
         // swallow the error
     }
 

--- a/source/packages/libraries/core/simple-cdf-logger/package.json
+++ b/source/packages/libraries/core/simple-cdf-logger/package.json
@@ -18,6 +18,7 @@
     "winston-transport": "4.4.0"
   },
   "devDependencies": {
+    "@awssolutions/cdf-config-inject": "workspace:^2.5.2",
     "@awssolutions/eslint-config-custom": "workspace:~0.0.0",
     "@typescript-eslint/eslint-plugin": "6.2.0",
     "eslint": "8.46.0",

--- a/source/packages/libraries/core/simple-cdf-logger/src/index.ts
+++ b/source/packages/libraries/core/simple-cdf-logger/src/index.ts
@@ -1,3 +1,5 @@
+import '@awssolutions/cdf-config-inject';
+
 import { format } from 'logform';
 import { LoggerOptions, createLogger, transports } from 'winston';
 const { combine, timestamp, printf } = format;
@@ -19,19 +21,25 @@ export function setRequestId(newRequestId: string) {
     }
 }
 
-export const logger = createLogger(<LoggerOptions>{
-    level,
-    exitOnError: false,
-    transports: [new transports.Console()],
-    format: combine(
-        timestamp(),
-        printf((nfo) => {
-            return `${nfo.timestamp} ${nfo.level}: rid-${requestId ? requestId : 'not-set-yet'}: ${
-                nfo.message
-            }`;
-        })
-    ),
-});
+export const logger = (function () {
+    if (typeof level == 'undefined') {
+        // this indicates that no log level was set through .env (see: cdf-config-inject)
+        console.error('LOGGING_LEVEL not set');
+    }
+    return createLogger(<LoggerOptions>{
+        level,
+        exitOnError: false,
+        transports: [new transports.Console()],
+        format: combine(
+            timestamp(),
+            printf((nfo) => {
+                return `${nfo.timestamp} ${nfo.level}: rid-${
+                    requestId ? requestId : 'not-set-yet'
+                }: ${nfo.message}`;
+            })
+        ),
+    });
+})();
 
 export function getRequestIdFromContext(context: any) {
     let requestId;

--- a/source/packages/services/assetlibraryhistory/src/lambda_iot_rule.ts
+++ b/source/packages/services/assetlibraryhistory/src/lambda_iot_rule.ts
@@ -12,8 +12,8 @@
  *********************************************************************************************************************/
 import 'reflect-metadata';
 
-import { logger } from '@awssolutions/simple-cdf-logger';
 import { container } from './di/inversify.config';
+import { logger } from '@awssolutions/simple-cdf-logger';
 import { TYPES } from './di/types';
 import { EventModel } from './events/events.models';
 import { EventsService } from './events/events.service';

--- a/source/packages/services/bulkcerts/src/lambda_sns_handler.ts
+++ b/source/packages/services/bulkcerts/src/lambda_sns_handler.ts
@@ -10,12 +10,13 @@
  *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions    *
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
+import { container } from './di/inversify.config';
+
 import { logger } from '@awssolutions/simple-cdf-logger';
 import { Context, SNSEvent } from 'aws-lambda';
 import ow from 'ow';
 import { CertificateChunkRequest } from './certificates/certificates.models';
 import { CertificatesService } from './certificates/certificates.service';
-import { container } from './di/inversify.config';
 import { TYPES } from './di/types';
 
 let service: CertificatesService;

--- a/source/packages/services/command-and-control/src/lambda_shadow_command_response_handler.ts
+++ b/source/packages/services/command-and-control/src/lambda_shadow_command_response_handler.ts
@@ -13,8 +13,8 @@
 
 import ow from 'ow';
 
-import { logger } from '@awssolutions/simple-cdf-logger';
 import { container } from './di/inversify.config';
+import { logger } from '@awssolutions/simple-cdf-logger';
 import { TYPES } from './di/types';
 import { Response } from './responses/responses.models';
 import { ResponsesService } from './responses/responses.service';

--- a/source/packages/services/command-and-control/src/lambda_topic_command_response_handler.ts
+++ b/source/packages/services/command-and-control/src/lambda_topic_command_response_handler.ts
@@ -13,8 +13,8 @@
 
 import ow from 'ow';
 
-import { logger } from '@awssolutions/simple-cdf-logger';
 import { container } from './di/inversify.config';
+import { logger } from '@awssolutions/simple-cdf-logger';
 import { TYPES } from './di/types';
 import { Response } from './responses/responses.models';
 import { ResponsesService } from './responses/responses.service';

--- a/source/packages/services/command-and-control/src/messages/workflow/workflow.createEphemeralGroup.ts
+++ b/source/packages/services/command-and-control/src/messages/workflow/workflow.createEphemeralGroup.ts
@@ -80,8 +80,10 @@ export class CreateEphemeralGroupAction extends WorkflowPublishAction {
                 thingNames.map((t) => t.id)
             );
 
-            // as we have created an ephemeral group from the target, we can remove the things from the resolved targets lit
-            // TODO: removing resolved targets means their status will never change from 'pending'. This is to address issues with batching. if status is required then a rethink and redesign of job batching is required. As a workaround, if recipient status is needed it can be retrieved directly from the AWS IoT job execution status.
+            // as we have created an ephemeral group from the target, we can remove the things from the resolved targets list
+            // TODO: removing resolved targets means their status will never change from 'pending'.
+            // This is to address issues with batching. if status is required then a rethink and redesign of job batching is required.
+            // As a workaround, if recipient status is needed it can be retrieved directly from the AWS IoT job execution status.
             resolvedTargets = resolvedTargets.filter((o) => o.type !== 'thing');
             resolvedTargets.push({
                 id: ephemeralGroupResponse.groupName,

--- a/source/packages/services/device-patcher/src/patch/patch.dao.ts
+++ b/source/packages/services/device-patcher/src/patch/patch.dao.ts
@@ -322,8 +322,18 @@ export class PatchDao {
             },
         };
 
-        const queryResults = await this.dc.query(queryParams).promise();
-        if (queryResults.Items === undefined || queryResults.Items.length === 0) {
+        let queryResults;
+        try {
+            queryResults = await this.dc.query(queryParams).promise();
+        } catch (err) {
+            logger.error(
+                `patch.dao: delete: query: params: ${JSON.stringify(
+                    queryParams
+                )}, error: ${JSON.stringify(err)}`
+            );
+            throw err;
+        }
+        if (queryResults?.Items === undefined || queryResults?.Items.length === 0) {
             logger.debug('patches.dao delete: exit: nothing to delete');
             return;
         }

--- a/source/packages/services/events-processor/src/lambda_proxy_ddbstream.ts
+++ b/source/packages/services/events-processor/src/lambda_proxy_ddbstream.ts
@@ -10,8 +10,9 @@
  *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions    *
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
-import { logger } from '@awssolutions/simple-cdf-logger';
 import { container } from './di/inversify.config';
+
+import { logger } from '@awssolutions/simple-cdf-logger';
 import { TYPES } from './di/types';
 import { FilterService } from './filter/filter.service';
 import { DDBStreamTransformer } from './transformers/ddbstream.transformer';

--- a/source/packages/services/events-processor/src/lambda_proxy_invoke.ts
+++ b/source/packages/services/events-processor/src/lambda_proxy_invoke.ts
@@ -10,8 +10,9 @@
  *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions    *
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
-import { logger } from '@awssolutions/simple-cdf-logger';
 import { container } from './di/inversify.config';
+
+import { logger } from '@awssolutions/simple-cdf-logger';
 import { TYPES } from './di/types';
 import { FilterService } from './filter/filter.service';
 

--- a/source/packages/services/events-processor/src/lambda_sqs_proxy.ts
+++ b/source/packages/services/events-processor/src/lambda_sqs_proxy.ts
@@ -10,10 +10,10 @@
  *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions    *
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
+import { container } from './di/inversify.config';
 
 import { logger } from '@awssolutions/simple-cdf-logger';
 import { SubscriptionService } from './api/subscriptions/subscription.service';
-import { container } from './di/inversify.config';
 import { TYPES } from './di/types';
 
 let subscriptionService: SubscriptionService;

--- a/source/packages/services/events-processor/src/utils/errors.util.ts
+++ b/source/packages/services/events-processor/src/utils/errors.util.ts
@@ -58,5 +58,7 @@ export function handleError(e: Error, res: Response): void {
         res.status(500).json({ error: res.statusMessage }).end();
     }
 
-    logger.error(`errors.util handleError: exit: ${res.status}`);
+    logger.error(
+        `errors.util handleError: exit: res status:${res.statusCode}, message: ${res.statusMessage}`
+    );
 }

--- a/source/packages/services/greengrass2-provisioning/README.md
+++ b/source/packages/services/greengrass2-provisioning/README.md
@@ -352,7 +352,7 @@ Content-Type: application/vnd.aws-cdf-v1.0+json
 
 ### Create a deployment task
 
-A deployment task is what takes the components defined in the template and create a Greengrass2 deployment job. As this can take time, is an asynchronous process, with the response header `x-taskId` identifying the task.
+A deployment task is what takes the components defined in the template and creates a Greengrass2 deployment job. As this can take time, it is an asynchronous process, with the response header `x-taskId` identifying the task.
 
 Replace the following:
 

--- a/source/packages/services/greengrass2-provisioning/src/lambda_ddbstream_proxy.ts
+++ b/source/packages/services/greengrass2-provisioning/src/lambda_ddbstream_proxy.ts
@@ -11,9 +11,9 @@
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
 import { AttributeValue, DynamoDBStreamEvent } from 'aws-lambda';
+import { container } from './di/inversify.config';
 
 import { logger } from '@awssolutions/simple-cdf-logger';
-import { container } from './di/inversify.config';
 import { TYPES } from './di/types';
 import { FleetService, TemplateAttributes } from './fleet/fleet.service';
 import { PkType, expandDelimitedAttribute } from './utils/pkUtils.util';

--- a/source/packages/services/greengrass2-provisioning/src/lambda_job_execution_proxy.ts
+++ b/source/packages/services/greengrass2-provisioning/src/lambda_job_execution_proxy.ts
@@ -10,13 +10,14 @@
  *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions    *
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
+import { container } from './di/inversify.config';
+
 import { CDFEventPublisher, EVENT_PUBLISHER_TYPES } from '@awssolutions/cdf-event-publisher';
 import { logger } from '@awssolutions/simple-cdf-logger';
 import { CoreTemplateUpdatedEvent, CoreTemplateUpdatedPayload } from './cores/cores.models';
 import { CoresService } from './cores/cores.service';
 import { DeploymentTasksService } from './deploymentTasks/deploymentTasks.service';
 import { DeploymentsService } from './deployments/deployments.service';
-import { container } from './di/inversify.config';
 import { TYPES } from './di/types';
 
 const coresService = container.get<CoresService>(TYPES.CoresService);

--- a/source/packages/services/greengrass2-provisioning/src/lambda_sqs_proxy.ts
+++ b/source/packages/services/greengrass2-provisioning/src/lambda_sqs_proxy.ts
@@ -10,11 +10,12 @@
  *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions    *
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
+import { container } from './di/inversify.config';
+
 import { logger } from '@awssolutions/simple-cdf-logger';
 import { CoreTasksService } from './coreTasks/coreTasks.service';
 import { DeploymentTasksService } from './deploymentTasks/deploymentTasks.service';
 import { DeviceTasksService } from './deviceTasks/deviceTasks.service';
-import { container } from './di/inversify.config';
 import { TYPES } from './di/types';
 
 const coreTasksSvc: CoreTasksService = container.get(TYPES.CoreTasksService);

--- a/source/packages/services/installer/README.md
+++ b/source/packages/services/installer/README.md
@@ -165,7 +165,7 @@ You can generate the `.env` file automatically for running modules locally. This
 | `output-folder` | the folder to store the generated env file(s) |
 
 ```shell
-> cdf-cli cloud-to-env <environment> <region> <output-folder>
+> cdf-cli generate-local-config <environment> <region> <output-folder>
 ```
 
 The `.env` file for each of the deployed modules will be generated in the `output-folder`.

--- a/source/packages/services/organization-manager/src/lambda_proxy_eventbridge.ts
+++ b/source/packages/services/organization-manager/src/lambda_proxy_eventbridge.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
 import 'reflect-metadata';
+import { container } from './di/inversify.config';
 
 import { logger } from '@awssolutions/simple-cdf-logger';
 import { Context, EventBridgeEvent } from 'aws-lambda';
@@ -22,7 +23,6 @@ import {
 } from './accounts/accounts.models';
 import { AccountsService } from './accounts/accounts.service';
 import { ComponentsService } from './components/components.service';
-import { container } from './di/inversify.config';
 import { TYPES } from './di/types';
 import { ManifestService } from './manifest/manifest.service';
 


### PR DESCRIPTION
# Description
- Main change is to add to the device-patcher teardowns to delete the patches created in the course of the tests. There isn't a straightforward way to delete the tasks as well, but so far, those don't seem to be causing errors. We can revisit later.
- re-enabled patch.feature test because correcting the teardown should ensure that it works consistently
- config-inject added to the logger because it's required for the config values to be loaded before logger creation (log level is in configs), also reordered some imports because of this
- updated the logger to warn if the configuration hasn't been set when it's created (though that should be impossible now)
- added more specific error logging and cleaned up some typos
- updated to vscode new value for organizingImports

## Type of change

- [x ] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change includes a documentation update*

# Submission Checklist

- [ ] CI dry-run passing
- [x ] Integration tests passing locally
- [ ] Change logs generated 

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->
