### PR TITLE
device-monitoring: lambda memory size increase

### DIFF
--- a/source/common/changes/@awssolutions/cdf-device-monitoring/fix_device_monitoring_lambda_memory_2024-02-08-20-41.json
+++ b/source/common/changes/@awssolutions/cdf-device-monitoring/fix_device_monitoring_lambda_memory_2024-02-08-20-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@awssolutions/cdf-device-monitoring",
+      "comment": "increased lambda function size to 512MB",
+      "type": "none"
+    }
+  ],
+  "packageName": "@awssolutions/cdf-device-monitoring"
+}

--- a/source/packages/services/device-monitoring/infrastructure/cfn-device-monitoring.yml
+++ b/source/packages/services/device-monitoring/infrastructure/cfn-device-monitoring.yml
@@ -110,7 +110,7 @@ Resources:
       FunctionName: !Sub 'cdf-deviceMonitoring-${Environment}'
       CodeUri: ../bundle.zip
       Handler: iot_lifecycle_event.lambda_handler
-      MemorySize: 128
+      MemorySize: 512
       Role: !GetAtt IoTLifecycleLambdaRole.Arn
       Runtime: nodejs18.x
       Timeout: 29


### PR DESCRIPTION
# Description
<!-- Briefly describe noteworthy details -->
The device monitoring lambda regularly uses ~300MB per lambda invocation. 128MB will not even run, the lambdas are timing out.

![Screenshot 2024-02-08 at 3 53 29 PM](https://github.com/aws/aws-connected-device-framework/assets/89797921/ce0b739d-4367-45f8-8fc0-e4347f0c4b95)


## Type of change

- [x] *Bug fix (non-breaking change which fixes an issue)*
- [ ] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change includes a documentation update*

# Submission Checklist

- [x] CI dry-run passing
- [x] Integration tests passing locally
- [x] Change logs generated 

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->
