### PR TITLE
feat: add custom user agent header string in AWS SDK clients

### DIFF
--- a/source/common/config/rush/pnpm-lock.yaml
+++ b/source/common/config/rush/pnpm-lock.yaml
@@ -2296,9 +2296,9 @@ importers:
 
   ../../packages/services/assetlibrary:
     dependencies:
-      '@awssolutions/cdf-version':
+      '@awssolutions/cdf-attribution':
         specifier: workspace:~0.0.0
-        version: link:../../libraries/core/version
+        version: link:../../libraries/core/attribution
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2
@@ -2477,9 +2477,9 @@ importers:
 
   ../../packages/services/assetlibrary-export:
     dependencies:
-      '@awssolutions/cdf-version':
+      '@awssolutions/cdf-attribution':
         specifier: workspace:~0.0.0
-        version: link:../../libraries/core/version
+        version: link:../../libraries/core/attribution
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2
@@ -2646,9 +2646,9 @@ importers:
 
   ../../packages/services/assetlibraryhistory:
     dependencies:
-      '@awssolutions/cdf-version':
+      '@awssolutions/cdf-attribution':
         specifier: workspace:~0.0.0
-        version: link:../../libraries/core/version
+        version: link:../../libraries/core/attribution
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2
@@ -2991,9 +2991,9 @@ importers:
 
   ../../packages/services/bulkcerts:
     dependencies:
-      '@awssolutions/cdf-version':
+      '@awssolutions/cdf-attribution':
         specifier: workspace:~0.0.0
-        version: link:../../libraries/core/version
+        version: link:../../libraries/core/attribution
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2
@@ -3148,9 +3148,9 @@ importers:
 
   ../../packages/services/certificateactivator:
     dependencies:
-      '@awssolutions/cdf-version':
+      '@awssolutions/cdf-attribution':
         specifier: workspace:~0.0.0
-        version: link:../../libraries/core/version
+        version: link:../../libraries/core/attribution
     devDependencies:
       '@awssolutions/cdf-assetlibrary-client':
         specifier: workspace:^2.5.2
@@ -3284,9 +3284,9 @@ importers:
 
   ../../packages/services/certificatevendor:
     dependencies:
-      '@awssolutions/cdf-version':
+      '@awssolutions/cdf-attribution':
         specifier: workspace:~0.0.0
-        version: link:../../libraries/core/version
+        version: link:../../libraries/core/attribution
     devDependencies:
       '@awssolutions/cdf-assetlibrary-client':
         specifier: workspace:^2.5.2
@@ -3405,9 +3405,9 @@ importers:
 
   ../../packages/services/command-and-control:
     dependencies:
-      '@awssolutions/cdf-version':
+      '@awssolutions/cdf-attribution':
         specifier: workspace:~0.0.0
-        version: link:../../libraries/core/version
+        version: link:../../libraries/core/attribution
     devDependencies:
       '@awssolutions/cdf-assetlibrary-client':
         specifier: workspace:^2.5.2
@@ -3854,9 +3854,9 @@ importers:
 
   ../../packages/services/device-patcher:
     dependencies:
-      '@awssolutions/cdf-version':
+      '@awssolutions/cdf-attribution':
         specifier: workspace:~0.0.0
-        version: link:../../libraries/core/version
+        version: link:../../libraries/core/attribution
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2
@@ -4026,9 +4026,9 @@ importers:
 
   ../../packages/services/events-alerts:
     dependencies:
-      '@awssolutions/cdf-version':
+      '@awssolutions/cdf-attribution':
         specifier: workspace:~0.0.0
-        version: link:../../libraries/core/version
+        version: link:../../libraries/core/attribution
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2
@@ -4153,9 +4153,9 @@ importers:
 
   ../../packages/services/events-processor:
     dependencies:
-      '@awssolutions/cdf-version':
+      '@awssolutions/cdf-attribution':
         specifier: workspace:~0.0.0
-        version: link:../../libraries/core/version
+        version: link:../../libraries/core/attribution
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2
@@ -4415,9 +4415,9 @@ importers:
 
   ../../packages/services/greengrass2-provisioning:
     dependencies:
-      '@awssolutions/cdf-version':
+      '@awssolutions/cdf-attribution':
         specifier: workspace:~0.0.0
-        version: link:../../libraries/core/version
+        version: link:../../libraries/core/attribution
     devDependencies:
       '@aws-sdk/abort-controller':
         specifier: 3.38.0
@@ -4777,9 +4777,9 @@ importers:
 
   ../../packages/services/organization-manager:
     dependencies:
-      '@awssolutions/cdf-version':
+      '@awssolutions/cdf-attribution':
         specifier: workspace:~0.0.0
-        version: link:../../libraries/core/version
+        version: link:../../libraries/core/attribution
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2
@@ -4922,9 +4922,9 @@ importers:
 
   ../../packages/services/provisioning:
     dependencies:
-      '@awssolutions/cdf-version':
+      '@awssolutions/cdf-attribution':
         specifier: workspace:~0.0.0
-        version: link:../../libraries/core/version
+        version: link:../../libraries/core/attribution
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2

--- a/source/common/config/rush/pnpm-lock.yaml
+++ b/source/common/config/rush/pnpm-lock.yaml
@@ -2279,6 +2279,10 @@ importers:
         version: 4.2.4
 
   ../../packages/services/assetlibrary:
+    dependencies:
+      '@awssolutions/cdf-version':
+        specifier: workspace:~0.0.0
+        version: link:../../libraries/core/version
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2
@@ -2456,6 +2460,10 @@ importers:
         version: 4.4.0
 
   ../../packages/services/assetlibrary-export:
+    dependencies:
+      '@awssolutions/cdf-version':
+        specifier: workspace:~0.0.0
+        version: link:../../libraries/core/version
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2
@@ -2621,6 +2629,10 @@ importers:
         version: 4.3.0
 
   ../../packages/services/assetlibraryhistory:
+    dependencies:
+      '@awssolutions/cdf-version':
+        specifier: workspace:~0.0.0
+        version: link:../../libraries/core/version
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2
@@ -2962,6 +2974,10 @@ importers:
         version: 4.2.4
 
   ../../packages/services/bulkcerts:
+    dependencies:
+      '@awssolutions/cdf-version':
+        specifier: workspace:~0.0.0
+        version: link:../../libraries/core/version
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2
@@ -3115,6 +3131,10 @@ importers:
         version: 4.4.0
 
   ../../packages/services/certificateactivator:
+    dependencies:
+      '@awssolutions/cdf-version':
+        specifier: workspace:~0.0.0
+        version: link:../../libraries/core/version
     devDependencies:
       '@awssolutions/cdf-assetlibrary-client':
         specifier: workspace:^2.5.2
@@ -3247,6 +3267,10 @@ importers:
         version: 4.4.0
 
   ../../packages/services/certificatevendor:
+    dependencies:
+      '@awssolutions/cdf-version':
+        specifier: workspace:~0.0.0
+        version: link:../../libraries/core/version
     devDependencies:
       '@awssolutions/cdf-assetlibrary-client':
         specifier: workspace:^2.5.2
@@ -3364,6 +3388,10 @@ importers:
         version: 4.4.0
 
   ../../packages/services/command-and-control:
+    dependencies:
+      '@awssolutions/cdf-version':
+        specifier: workspace:~0.0.0
+        version: link:../../libraries/core/version
     devDependencies:
       '@awssolutions/cdf-assetlibrary-client':
         specifier: workspace:^2.5.2
@@ -3809,6 +3837,10 @@ importers:
         version: 4.4.0
 
   ../../packages/services/device-patcher:
+    dependencies:
+      '@awssolutions/cdf-version':
+        specifier: workspace:~0.0.0
+        version: link:../../libraries/core/version
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2
@@ -3977,6 +4009,10 @@ importers:
         version: 4.4.0
 
   ../../packages/services/events-alerts:
+    dependencies:
+      '@awssolutions/cdf-version':
+        specifier: workspace:~0.0.0
+        version: link:../../libraries/core/version
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2
@@ -4100,6 +4136,10 @@ importers:
         version: 4.4.0
 
   ../../packages/services/events-processor:
+    dependencies:
+      '@awssolutions/cdf-version':
+        specifier: workspace:~0.0.0
+        version: link:../../libraries/core/version
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2
@@ -4358,6 +4398,10 @@ importers:
         version: 1.10.2
 
   ../../packages/services/greengrass2-provisioning:
+    dependencies:
+      '@awssolutions/cdf-version':
+        specifier: workspace:~0.0.0
+        version: link:../../libraries/core/version
     devDependencies:
       '@aws-sdk/abort-controller':
         specifier: 3.38.0
@@ -4716,6 +4760,10 @@ importers:
         version: 4.2.4
 
   ../../packages/services/organization-manager:
+    dependencies:
+      '@awssolutions/cdf-version':
+        specifier: workspace:~0.0.0
+        version: link:../../libraries/core/version
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2
@@ -4857,6 +4905,10 @@ importers:
         version: 4.4.0
 
   ../../packages/services/provisioning:
+    dependencies:
+      '@awssolutions/cdf-version':
+        specifier: workspace:~0.0.0
+        version: link:../../libraries/core/version
     devDependencies:
       '@awssolutions/cdf-config-inject':
         specifier: workspace:^2.5.2

--- a/source/common/config/rush/pnpm-lock.yaml
+++ b/source/common/config/rush/pnpm-lock.yaml
@@ -1389,6 +1389,9 @@ importers:
       '@awssolutions/eslint-config-custom':
         specifier: workspace:~0.0.0
         version: link:../../config/eslint-config-custom
+      '@typescript-eslint/eslint-plugin':
+        specifier: 6.2.0
+        version: 6.2.0(@typescript-eslint/parser@6.2.0)(eslint@8.46.0)(supports-color@8.0.0)(typescript@4.2.4)
       typescript:
         specifier: 4.2.4
         version: 4.2.4
@@ -2166,6 +2169,9 @@ importers:
       '@awssolutions/eslint-config-custom':
         specifier: workspace:~0.0.0
         version: link:../../config/eslint-config-custom
+      '@typescript-eslint/eslint-plugin':
+        specifier: 6.2.0
+        version: 6.2.0(@typescript-eslint/parser@6.2.0)(eslint@8.46.0)(supports-color@8.0.0)(typescript@4.2.4)
       ts-morph:
         specifier: ~22.0.0
         version: 22.0.0
@@ -9482,7 +9488,7 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
       eslint: 8.46.0(supports-color@8.0.0)
-      eslint-visitor-keys: 3.4.2
+      eslint-visitor-keys: 3.4.3
 
   /@eslint-community/regexpp@4.6.2:
     resolution: {integrity: sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==}
@@ -9496,7 +9502,7 @@ packages:
       debug: 4.3.4(supports-color@8.0.0)
       espree: 9.6.1
       globals: 13.20.0
-      ignore: 5.2.4
+      ignore: 5.3.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -10944,7 +10950,7 @@ packages:
       '@typescript-eslint/utils': 6.2.0(eslint@8.46.0)(supports-color@8.0.0)(typescript@4.2.4)
       debug: 4.3.4(supports-color@8.0.0)
       eslint: 8.46.0(supports-color@8.0.0)
-      ts-api-utils: 1.0.1(typescript@4.2.4)
+      ts-api-utils: 1.3.0(typescript@4.2.4)
       typescript: 4.2.4
     transitivePeerDependencies:
       - supports-color
@@ -10964,7 +10970,7 @@ packages:
       '@typescript-eslint/utils': 6.2.0(eslint@8.46.0)(typescript@4.9.4)
       debug: 4.3.4(supports-color@8.0.0)
       eslint: 8.46.0(supports-color@8.0.0)
-      ts-api-utils: 1.0.1(typescript@4.9.4)
+      ts-api-utils: 1.3.0(typescript@4.9.4)
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
@@ -10984,7 +10990,7 @@ packages:
       '@typescript-eslint/utils': 6.2.0(eslint@8.46.0)(typescript@4.9.5)
       debug: 4.3.4(supports-color@8.0.0)
       eslint: 8.46.0(supports-color@8.0.0)
-      ts-api-utils: 1.0.1(typescript@4.9.5)
+      ts-api-utils: 1.3.0(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
@@ -11008,8 +11014,8 @@ packages:
       debug: 4.3.4(supports-color@8.0.0)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.4
-      ts-api-utils: 1.0.1(typescript@4.2.4)
+      semver: 7.6.2
+      ts-api-utils: 1.3.0(typescript@4.2.4)
       typescript: 4.2.4
     transitivePeerDependencies:
       - supports-color
@@ -11029,8 +11035,8 @@ packages:
       debug: 4.3.4(supports-color@8.0.0)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.4
-      ts-api-utils: 1.0.1(typescript@4.9.4)
+      semver: 7.6.2
+      ts-api-utils: 1.3.0(typescript@4.9.4)
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
@@ -11050,8 +11056,8 @@ packages:
       debug: 4.3.4(supports-color@8.0.0)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.4
-      ts-api-utils: 1.0.1(typescript@4.9.5)
+      semver: 7.6.2
+      ts-api-utils: 1.3.0(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
@@ -11069,7 +11075,7 @@ packages:
       '@typescript-eslint/types': 6.2.0
       '@typescript-eslint/typescript-estree': 6.2.0(supports-color@8.0.0)(typescript@4.2.4)
       eslint: 8.46.0(supports-color@8.0.0)
-      semver: 7.5.4
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11088,7 +11094,7 @@ packages:
       '@typescript-eslint/types': 6.2.0
       '@typescript-eslint/typescript-estree': 6.2.0(typescript@4.9.4)
       eslint: 8.46.0(supports-color@8.0.0)
-      semver: 7.5.4
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11107,7 +11113,7 @@ packages:
       '@typescript-eslint/types': 6.2.0
       '@typescript-eslint/typescript-estree': 6.2.0(typescript@4.9.5)
       eslint: 8.46.0(supports-color@8.0.0)
-      semver: 7.5.4
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -13154,6 +13160,10 @@ packages:
     resolution: {integrity: sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  /eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   /eslint@8.46.0(supports-color@8.0.0):
     resolution: {integrity: sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -13445,16 +13455,6 @@ packages:
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  /fast-glob@3.3.1:
-    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
-    engines: {node: '>=8.6.0'}
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.5
-
   /fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
     engines: {node: '>=8.6.0'}
@@ -13464,7 +13464,6 @@ packages:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
-    dev: true
 
   /fast-json-patch@3.1.1:
     resolution: {integrity: sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==}
@@ -13880,8 +13879,8 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.3.1
-      ignore: 5.2.4
+      fast-glob: 3.3.2
+      ignore: 5.3.1
       merge2: 1.4.1
       slash: 3.0.0
 
@@ -14153,6 +14152,10 @@ packages:
 
   /ignore@5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
+    engines: {node: '>= 4'}
+
+  /ignore@5.3.1:
+    resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
     engines: {node: '>= 4'}
 
   /immediate@3.0.6:
@@ -15764,7 +15767,7 @@ packages:
       jest-resolve: 26.6.2
       natural-compare: 1.4.0
       pretty-format: 26.6.2
-      semver: 7.5.4
+      semver: 7.6.2
     dev: true
 
   /jest-snapshot@29.6.2:
@@ -15790,7 +15793,7 @@ packages:
       jest-util: 29.6.2
       natural-compare: 1.4.0
       pretty-format: 29.6.2
-      semver: 7.5.4
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -16434,7 +16437,7 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.2
     dev: true
 
   /make-error@1.3.6:
@@ -16883,7 +16886,7 @@ packages:
     dependencies:
       growly: 1.3.0
       is-wsl: 2.2.0
-      semver: 7.5.4
+      semver: 7.6.2
       shellwords: 0.1.1
       uuid: 8.3.2
       which: 2.0.2
@@ -18060,6 +18063,11 @@ packages:
     dependencies:
       lru-cache: 6.0.0
 
+  /semver@7.6.2:
+    resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
     engines: {node: '>= 0.8.0'}
@@ -18907,6 +18915,33 @@ packages:
   /ts-api-utils@1.0.1(typescript@4.9.5):
     resolution: {integrity: sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==}
     engines: {node: '>=16.13.0'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 4.9.5
+    dev: true
+
+  /ts-api-utils@1.3.0(typescript@4.2.4):
+    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 4.2.4
+    dev: true
+
+  /ts-api-utils@1.3.0(typescript@4.9.4):
+    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 4.9.4
+    dev: true
+
+  /ts-api-utils@1.3.0(typescript@4.9.5):
+    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
+    engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:

--- a/source/common/config/rush/pnpm-lock.yaml
+++ b/source/common/config/rush/pnpm-lock.yaml
@@ -1377,6 +1377,22 @@ importers:
         specifier: 8.46.0
         version: 8.46.0(supports-color@8.0.0)
 
+  ../../packages/libraries/core/attribution:
+    dependencies:
+      '@awssolutions/cdf-version':
+        specifier: workspace:~0.0.0
+        version: link:../version
+      '@types/node':
+        specifier: ^18.17.0
+        version: 18.17.0
+    devDependencies:
+      '@awssolutions/eslint-config-custom':
+        specifier: workspace:~0.0.0
+        version: link:../../config/eslint-config-custom
+      typescript:
+        specifier: 4.2.4
+        version: 4.2.4
+
   ../../packages/libraries/core/cdf-client-request-signer:
     dependencies:
       '@aws-sdk/credential-providers':
@@ -10301,7 +10317,7 @@ packages:
   /@types/aws4@1.11.2:
     resolution: {integrity: sha512-x0f96eBPrCCJzJxdPbUvDFRva4yPpINJzTuXXpmS2j9qLUpF2nyGzvXPlRziuGbCsPukwY4JfuO+8xwsoZLzGw==}
     dependencies:
-      '@types/node': 18.17.0
+      '@types/node': 18.17.1
     dev: true
 
   /@types/babel__core@7.20.1:
@@ -10459,7 +10475,7 @@ packages:
     resolution: {integrity: sha512-8bVUjXZvJacUFkJXHdyZ9iH1Eaj5V7I8c4NdH5sQJsdXkqT4CA5Dhb4yb4VE/3asyx4L9ayZr1NIhTsWHczmMw==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.11.18
+      '@types/node': 18.17.1
     dev: true
 
   /@types/graceful-fs@4.1.6:
@@ -10568,7 +10584,7 @@ packages:
   /@types/jsonwebtoken@9.0.1:
     resolution: {integrity: sha512-c5ltxazpWabia/4UzhIoaDcIza4KViOQhdbjRlfcIGVnsE3c3brkz9Z+F/EeJIECOQP7W7US2hNE930cWWkPiw==}
     dependencies:
-      '@types/node': 18.17.0
+      '@types/node': 18.17.1
     dev: true
 
   /@types/jwk-to-pem@2.0.0:
@@ -10722,7 +10738,7 @@ packages:
     resolution: {integrity: sha512-tLfnlJf6A5mB6ddqF159GqcDizfzbMUB1/DeT59/wBNqzRTNNKsaw79A/1TZ84X+f/EwWH8FeuSkjlCLyqS/zQ==}
     dependencies:
       '@types/cookiejar': 2.1.2
-      '@types/node': 18.17.0
+      '@types/node': 18.17.1
     dev: true
 
   /@types/through@0.0.30:

--- a/source/common/config/rush/repo-state.json
+++ b/source/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "f85cc14f59c4c9b6abdd1cf80944d1105fcb45bf",
+  "pnpmShrinkwrapHash": "c9e2e4d8a89a7c938b2900e21a13aeb319c23a58",
   "preferredVersionsHash": "14c05a7722342014cec64c4bef7d9bed0d0b7b7f"
 }

--- a/source/common/config/rush/repo-state.json
+++ b/source/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "c9e2e4d8a89a7c938b2900e21a13aeb319c23a58",
+  "pnpmShrinkwrapHash": "328f5bc9f8d94c978b7837809ed5ee0475813b52",
   "preferredVersionsHash": "14c05a7722342014cec64c4bef7d9bed0d0b7b7f"
 }

--- a/source/common/config/rush/repo-state.json
+++ b/source/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "bc7c93a1b9d3eb8bd6ef989abcdf674cf9379d76",
+  "pnpmShrinkwrapHash": "fa2b3bdcf3e13e230c0ca3e9c6f094f5f0042c31",
   "preferredVersionsHash": "14c05a7722342014cec64c4bef7d9bed0d0b7b7f"
 }

--- a/source/common/config/rush/repo-state.json
+++ b/source/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "328f5bc9f8d94c978b7837809ed5ee0475813b52",
+  "pnpmShrinkwrapHash": "bc7c93a1b9d3eb8bd6ef989abcdf674cf9379d76",
   "preferredVersionsHash": "14c05a7722342014cec64c4bef7d9bed0d0b7b7f"
 }

--- a/source/packages/libraries/core/attribution/.eslintrc.js
+++ b/source/packages/libraries/core/attribution/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ["@awssolutions/eslint-config-custom"],
+};

--- a/source/packages/libraries/core/attribution/package.json
+++ b/source/packages/libraries/core/attribution/package.json
@@ -9,12 +9,13 @@
     "clean": "npx shx rm -rf dist *.tsbuildinfo .rush .nyc_output *.log",
     "lint": "npx eslint . --ext '.ts'",
     "build": "npx tsc -p tsconfig.json",
-    "test": "rushx lint && jest --silent --passWithNoTests --maxWorkers=$JEST_MAX_WORKERS"
+    "test": "rushx lint"
   },
   "devDependencies": {
     "@awssolutions/eslint-config-custom": "workspace:~0.0.0",
     "@types/node": "^18.17.0",
-    "typescript": "4.2.4"
+    "typescript": "4.2.4",
+    "@typescript-eslint/eslint-plugin": "6.2.0"
   },
   "license": "ISC",
   "dependencies": {

--- a/source/packages/libraries/core/attribution/package.json
+++ b/source/packages/libraries/core/attribution/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@awssolutions/cdf-attribution",
+  "version": "0.0.0",
+  "description": "",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "clean": "npx shx rm -rf dist *.tsbuildinfo .rush .nyc_output *.log",
+    "lint": "npx eslint . --ext '.ts'",
+    "build": "npx tsc -p tsconfig.json",
+    "test": "rushx lint && jest --silent --passWithNoTests --maxWorkers=$JEST_MAX_WORKERS"
+  },
+  "devDependencies": {
+    "@awssolutions/eslint-config-custom": "workspace:~0.0.0",
+    "@types/node": "^18.17.0",
+    "typescript": "4.2.4"
+  },
+  "license": "ISC",
+  "dependencies": {
+    "@awssolutions/cdf-version": "workspace:~0.0.0",
+    "@types/node": "^18.17.0"
+  }
+}

--- a/source/packages/libraries/core/attribution/src/index.ts
+++ b/source/packages/libraries/core/attribution/src/index.ts
@@ -1,0 +1,7 @@
+import { version } from '@awssolutions/cdf-version';
+
+const ATTRIBUTION_ID = '99CF47E5-1F4E-4DB2-AB43-0E975D0C7888';
+
+export function getCustomUserAgent(suffix: string): string {
+    return `awssolutions/${ATTRIBUTION_ID}_${version}_${suffix}`;
+}

--- a/source/packages/libraries/core/attribution/tsconfig.json
+++ b/source/packages/libraries/core/attribution/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.libraries.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+  },
+  "references": [],
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/source/packages/libraries/core/version/package.json
+++ b/source/packages/libraries/core/version/package.json
@@ -9,13 +9,14 @@
     "clean": "npx shx rm -rf dist *.tsbuildinfo .rush .nyc_output *.log",
     "lint": "npx eslint . --ext '.ts'",
     "build": "npx ts-node --swc scripts/compile.ts",
-    "test": "rushx lint && jest --silent --passWithNoTests --maxWorkers=$JEST_MAX_WORKERS"
+    "test": "rushx lint"
   },
   "devDependencies": {
     "@awssolutions/eslint-config-custom": "workspace:~0.0.0",
     "@types/node": "^18.17.0",
     "typescript": "4.2.4",
-    "ts-morph": "~22.0.0"
+    "ts-morph": "~22.0.0",
+    "@typescript-eslint/eslint-plugin": "6.2.0"
   },
   "license": "ISC",
   "dependencies": {

--- a/source/packages/services/assetlibrary-export/package.json
+++ b/source/packages/services/assetlibrary-export/package.json
@@ -93,6 +93,6 @@
     "winston-transport": "4.3.0"
   },
   "dependencies": {
-    "@awssolutions/cdf-version": "workspace:~0.0.0"
+    "@awssolutions/cdf-attribution": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/assetlibrary-export/package.json
+++ b/source/packages/services/assetlibrary-export/package.json
@@ -91,5 +91,8 @@
     "typescript": "4.2.4",
     "winston": "3.2.1",
     "winston-transport": "4.3.0"
+  },
+  "dependencies": {
+    "@awssolutions/cdf-version": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/assetlibrary-export/src/di/inversify.config.ts
+++ b/source/packages/services/assetlibrary-export/src/di/inversify.config.ts
@@ -13,7 +13,7 @@
 import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
-import { version } from '@awssolutions/cdf-version';
+import { getCustomUserAgent } from '@awssolutions/cdf-attribution';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 import AWS from 'aws-sdk';
@@ -92,7 +92,7 @@ container.bind<interfaces.Factory<AWS.S3>>(TYPES.S3Factory).toFactory<AWS.S3>(()
         if (!container.isBound(TYPES.S3)) {
             const s3 = new AWS.S3({
                 region: process.env.AWS_REGION,
-                customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ale`,
+                customUserAgent: getCustomUserAgent('ale'),
             });
             container.bind<AWS.S3>(TYPES.S3).toConstantValue(s3);
         }

--- a/source/packages/services/assetlibrary-export/src/di/inversify.config.ts
+++ b/source/packages/services/assetlibrary-export/src/di/inversify.config.ts
@@ -13,6 +13,7 @@
 import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
+import { version } from '@awssolutions/cdf-version';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 import AWS from 'aws-sdk';
@@ -89,7 +90,10 @@ decorate(injectable(), AWS.S3);
 container.bind<interfaces.Factory<AWS.S3>>(TYPES.S3Factory).toFactory<AWS.S3>(() => {
     return () => {
         if (!container.isBound(TYPES.S3)) {
-            const s3 = new AWS.S3({ region: process.env.AWS_REGION });
+            const s3 = new AWS.S3({
+                region: process.env.AWS_REGION,
+                customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ale`,
+            });
             container.bind<AWS.S3>(TYPES.S3).toConstantValue(s3);
         }
         return container.get<AWS.S3>(TYPES.S3);

--- a/source/packages/services/assetlibrary/package.json
+++ b/source/packages/services/assetlibrary/package.json
@@ -98,5 +98,8 @@
     "typescript": "4.2.4",
     "winston": "3.3.3",
     "winston-transport": "4.4.0"
+  },
+  "dependencies": {
+    "@awssolutions/cdf-version": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/assetlibrary/package.json
+++ b/source/packages/services/assetlibrary/package.json
@@ -100,6 +100,6 @@
     "winston-transport": "4.4.0"
   },
   "dependencies": {
-    "@awssolutions/cdf-version": "workspace:~0.0.0"
+    "@awssolutions/cdf-attribution": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/assetlibrary/src/di/inversify.config.ts
+++ b/source/packages/services/assetlibrary/src/di/inversify.config.ts
@@ -14,7 +14,7 @@ import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
 
-import { version } from '@awssolutions/cdf-version';
+import { getCustomUserAgent } from '@awssolutions/cdf-attribution';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 import { NodeAssembler } from '../data/assembler';
@@ -67,7 +67,7 @@ container
                 const iotData = new AWS.IotData({
                     region: process.env.AWS_REGION,
                     endpoint: `https://${process.env.AWS_IOT_ENDPOINT}`,
-                    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_asl`,
+                    customUserAgent: getCustomUserAgent('asl'),
                 });
                 container.bind<AWS.IotData>(TYPES.IotData).toConstantValue(iotData);
             }

--- a/source/packages/services/assetlibrary/src/di/inversify.config.ts
+++ b/source/packages/services/assetlibrary/src/di/inversify.config.ts
@@ -14,6 +14,7 @@ import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
 
+import { version } from '@awssolutions/cdf-version';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 import { NodeAssembler } from '../data/assembler';
@@ -66,6 +67,7 @@ container
                 const iotData = new AWS.IotData({
                     region: process.env.AWS_REGION,
                     endpoint: `https://${process.env.AWS_IOT_ENDPOINT}`,
+                    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_asl`,
                 });
                 container.bind<AWS.IotData>(TYPES.IotData).toConstantValue(iotData);
             }

--- a/source/packages/services/assetlibraryhistory/package.json
+++ b/source/packages/services/assetlibraryhistory/package.json
@@ -90,6 +90,6 @@
     "winston-transport": "4.4.0"
   },
   "dependencies": {
-    "@awssolutions/cdf-version": "workspace:~0.0.0"
+    "@awssolutions/cdf-attribution": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/assetlibraryhistory/package.json
+++ b/source/packages/services/assetlibraryhistory/package.json
@@ -88,5 +88,8 @@
     "typescript": "4.2.4",
     "winston": "3.3.3",
     "winston-transport": "4.4.0"
+  },
+  "dependencies": {
+    "@awssolutions/cdf-version": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/assetlibraryhistory/src/di/inversify.config.ts
+++ b/source/packages/services/assetlibraryhistory/src/di/inversify.config.ts
@@ -14,6 +14,7 @@ import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
 
+import { version } from '@awssolutions/cdf-version';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 // Note: importing @controller's carries out a one time inversify metadata generation...
@@ -75,7 +76,10 @@ container
     .toFactory<AWS.DynamoDB.DocumentClient>(() => {
         return () => {
             if (!container.isBound(TYPES.DocumentClient)) {
-                const dc = new AWS.DynamoDB.DocumentClient({ region: process.env.AWS_REGION });
+                const dc = new AWS.DynamoDB.DocumentClient({
+                    region: process.env.AWS_REGION,
+                    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_alh`,
+                });
                 container
                     .bind<AWS.DynamoDB.DocumentClient>(TYPES.DocumentClient)
                     .toConstantValue(dc);

--- a/source/packages/services/assetlibraryhistory/src/di/inversify.config.ts
+++ b/source/packages/services/assetlibraryhistory/src/di/inversify.config.ts
@@ -14,7 +14,7 @@ import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
 
-import { version } from '@awssolutions/cdf-version';
+import { getCustomUserAgent } from '@awssolutions/cdf-attribution';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 // Note: importing @controller's carries out a one time inversify metadata generation...
@@ -78,7 +78,7 @@ container
             if (!container.isBound(TYPES.DocumentClient)) {
                 const dc = new AWS.DynamoDB.DocumentClient({
                     region: process.env.AWS_REGION,
-                    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_alh`,
+                    customUserAgent: getCustomUserAgent('alh'),
                 });
                 container
                     .bind<AWS.DynamoDB.DocumentClient>(TYPES.DocumentClient)

--- a/source/packages/services/bulkcerts/package.json
+++ b/source/packages/services/bulkcerts/package.json
@@ -94,6 +94,6 @@
     "winston-transport": "4.4.0"
   },
   "dependencies": {
-    "@awssolutions/cdf-version": "workspace:~0.0.0"
+    "@awssolutions/cdf-attribution": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/bulkcerts/package.json
+++ b/source/packages/services/bulkcerts/package.json
@@ -92,5 +92,8 @@
     "uuid": "8.3.2",
     "winston": "3.3.3",
     "winston-transport": "4.4.0"
+  },
+  "dependencies": {
+    "@awssolutions/cdf-version": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/bulkcerts/src/di/inversify.config.ts
+++ b/source/packages/services/bulkcerts/src/di/inversify.config.ts
@@ -13,7 +13,7 @@
 import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
-import { version } from '@awssolutions/cdf-version';
+import { getCustomUserAgent } from '@awssolutions/cdf-attribution';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 import '../certificates/certificates.controller';
@@ -87,7 +87,7 @@ container
     .inSingletonScope();
 
 AWS.config.update({
-    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_bct`,
+    customUserAgent: getCustomUserAgent('bct'),
 });
 
 // for 3rd party objects, we need to use factory injectors

--- a/source/packages/services/bulkcerts/src/di/inversify.config.ts
+++ b/source/packages/services/bulkcerts/src/di/inversify.config.ts
@@ -13,6 +13,7 @@
 import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
+import { version } from '@awssolutions/cdf-version';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 import '../certificates/certificates.controller';
@@ -84,6 +85,10 @@ container
     .bind<CertificatesTaskDao>(TYPES.CertificatesTaskDao)
     .to(CertificatesTaskDao)
     .inSingletonScope();
+
+AWS.config.update({
+    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_bct`,
+});
 
 // for 3rd party objects, we need to use factory injectors
 // DynamoDB

--- a/source/packages/services/certificateactivator/package.json
+++ b/source/packages/services/certificateactivator/package.json
@@ -82,5 +82,8 @@
     "typescript": "4.2.4",
     "winston": "3.3.3",
     "winston-transport": "4.4.0"
+  },
+  "dependencies": {
+    "@awssolutions/cdf-version": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/certificateactivator/package.json
+++ b/source/packages/services/certificateactivator/package.json
@@ -84,6 +84,6 @@
     "winston-transport": "4.4.0"
   },
   "dependencies": {
-    "@awssolutions/cdf-version": "workspace:~0.0.0"
+    "@awssolutions/cdf-attribution": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/certificateactivator/src/di/inversify.config.ts
+++ b/source/packages/services/certificateactivator/src/di/inversify.config.ts
@@ -13,6 +13,7 @@
 import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
+import { version } from '@awssolutions/cdf-version';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 import { assetLibraryContainerModule } from '@awssolutions/cdf-assetlibrary-client';
@@ -33,6 +34,10 @@ container.bind<string>('aws.s3.crl.bucket').toConstantValue(process.env.AWS_S3_C
 container.bind<string>('aws.s3.crl.key').toConstantValue(process.env.AWS_S3_CRL_KEY);
 
 container.bind<ActivationService>(TYPES.ActivationService).to(ActivationService);
+
+AWS.config.update({
+    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_cta`,
+});
 
 // for 3rd party objects, we need to use factory injectors
 decorate(injectable(), AWS.Iot);

--- a/source/packages/services/certificateactivator/src/di/inversify.config.ts
+++ b/source/packages/services/certificateactivator/src/di/inversify.config.ts
@@ -13,7 +13,7 @@
 import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
-import { version } from '@awssolutions/cdf-version';
+import { getCustomUserAgent } from '@awssolutions/cdf-attribution';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 import { assetLibraryContainerModule } from '@awssolutions/cdf-assetlibrary-client';
@@ -36,7 +36,7 @@ container.bind<string>('aws.s3.crl.key').toConstantValue(process.env.AWS_S3_CRL_
 container.bind<ActivationService>(TYPES.ActivationService).to(ActivationService);
 
 AWS.config.update({
-    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_cta`,
+    customUserAgent: getCustomUserAgent('cta'),
 });
 
 // for 3rd party objects, we need to use factory injectors

--- a/source/packages/services/certificatevendor/package.json
+++ b/source/packages/services/certificatevendor/package.json
@@ -74,5 +74,8 @@
     "typescript": "4.2.4",
     "winston": "3.3.3",
     "winston-transport": "4.4.0"
+  },
+  "dependencies": {
+    "@awssolutions/cdf-version": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/certificatevendor/package.json
+++ b/source/packages/services/certificatevendor/package.json
@@ -76,6 +76,6 @@
     "winston-transport": "4.4.0"
   },
   "dependencies": {
-    "@awssolutions/cdf-version": "workspace:~0.0.0"
+    "@awssolutions/cdf-attribution": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/certificatevendor/src/di/inversify.config.ts
+++ b/source/packages/services/certificatevendor/src/di/inversify.config.ts
@@ -14,6 +14,7 @@ import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
 
+import { version } from '@awssolutions/cdf-version';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 import { assetLibraryContainerModule } from '@awssolutions/cdf-assetlibrary-client';
@@ -99,6 +100,10 @@ if (registry === 'AssetLibrary') {
 }
 
 container.bind<CertificateService>(TYPES.CertificateService).to(CertificateService);
+
+AWS.config.update({
+    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ctv`,
+});
 
 // for 3rd party objects, we need to use factory injectors
 decorate(injectable(), AWS.Iot);

--- a/source/packages/services/certificatevendor/src/di/inversify.config.ts
+++ b/source/packages/services/certificatevendor/src/di/inversify.config.ts
@@ -14,7 +14,7 @@ import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
 
-import { version } from '@awssolutions/cdf-version';
+import { getCustomUserAgent } from '@awssolutions/cdf-attribution';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 import { assetLibraryContainerModule } from '@awssolutions/cdf-assetlibrary-client';
@@ -102,7 +102,7 @@ if (registry === 'AssetLibrary') {
 container.bind<CertificateService>(TYPES.CertificateService).to(CertificateService);
 
 AWS.config.update({
-    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ctv`,
+    customUserAgent: getCustomUserAgent('ctv'),
 });
 
 // for 3rd party objects, we need to use factory injectors

--- a/source/packages/services/command-and-control/package.json
+++ b/source/packages/services/command-and-control/package.json
@@ -96,5 +96,8 @@
     "typescript": "4.2.4",
     "winston": "3.3.3",
     "winston-transport": "4.4.0"
+  },
+  "dependencies": {
+    "@awssolutions/cdf-version": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/command-and-control/package.json
+++ b/source/packages/services/command-and-control/package.json
@@ -98,6 +98,6 @@
     "winston-transport": "4.4.0"
   },
   "dependencies": {
-    "@awssolutions/cdf-version": "workspace:~0.0.0"
+    "@awssolutions/cdf-attribution": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/command-and-control/src/di/inversify.config.ts
+++ b/source/packages/services/command-and-control/src/di/inversify.config.ts
@@ -18,7 +18,7 @@ import AWS from 'aws-sdk';
 import { assetLibraryContainerModule } from '@awssolutions/cdf-assetlibrary-client';
 import { provisioningContainerModule } from '@awssolutions/cdf-provisioning-client';
 import { thingListBuilderContainerModule } from '@awssolutions/cdf-thing-list-builder';
-import { version } from '@awssolutions/cdf-version';
+import { getCustomUserAgent } from '@awssolutions/cdf-attribution';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 import { CommandsAssembler } from '../commands/commands.assembler';
 import { CommandsDao } from '../commands/commands.dao';
@@ -115,7 +115,7 @@ container.bind<DynamoDbUtils>(TYPES.DynamoDbUtils).to(DynamoDbUtils);
 
 AWS.config.update({
     region: process.env.AWS_REGION,
-    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_cnc`,
+    customUserAgent: getCustomUserAgent('cnc'),
 });
 
 // for 3rd party objects, we need to use factory injectors

--- a/source/packages/services/command-and-control/src/di/inversify.config.ts
+++ b/source/packages/services/command-and-control/src/di/inversify.config.ts
@@ -18,6 +18,7 @@ import AWS from 'aws-sdk';
 import { assetLibraryContainerModule } from '@awssolutions/cdf-assetlibrary-client';
 import { provisioningContainerModule } from '@awssolutions/cdf-provisioning-client';
 import { thingListBuilderContainerModule } from '@awssolutions/cdf-thing-list-builder';
+import { version } from '@awssolutions/cdf-version';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 import { CommandsAssembler } from '../commands/commands.assembler';
 import { CommandsDao } from '../commands/commands.dao';
@@ -112,7 +113,10 @@ container.bind<CheckBulkProvisioningAction>(TYPES.CheckBulkProvisioningAction).t
 
 container.bind<DynamoDbUtils>(TYPES.DynamoDbUtils).to(DynamoDbUtils);
 
-AWS.config.update({ region: process.env.AWS_REGION });
+AWS.config.update({
+    region: process.env.AWS_REGION,
+    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_cnc`,
+});
 
 // for 3rd party objects, we need to use factory injectors
 decorate(injectable(), AWS.DynamoDB.DocumentClient);

--- a/source/packages/services/device-patcher/package.json
+++ b/source/packages/services/device-patcher/package.json
@@ -96,6 +96,6 @@
     "winston-transport": "4.4.0"
   },
   "dependencies": {
-    "@awssolutions/cdf-version": "workspace:~0.0.0"
+    "@awssolutions/cdf-attribution": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/device-patcher/package.json
+++ b/source/packages/services/device-patcher/package.json
@@ -94,5 +94,8 @@
     "uuid": "8.3.2",
     "winston": "3.3.3",
     "winston-transport": "4.4.0"
+  },
+  "dependencies": {
+    "@awssolutions/cdf-version": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/device-patcher/src/di/inversify.config.ts
+++ b/source/packages/services/device-patcher/src/di/inversify.config.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
 import '@awssolutions/cdf-config-inject';
+import { version } from '@awssolutions/cdf-version';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 import 'reflect-metadata';
 
@@ -97,6 +98,10 @@ container.bind<ActivationDao>(TYPES.ActivationDao).to(ActivationDao).inSingleton
 
 container.bind<DynamoDbUtils>(TYPES.DynamoDbUtils).to(DynamoDbUtils).inSingletonScope();
 container.bind<ExpressionParser>(TYPES.ExpressionParser).to(ExpressionParser).inSingletonScope();
+
+AWS.config.update({
+    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_dvp`,
+});
 
 // for 3rd party objects, we need to use factory injectors
 // DynamoDB

--- a/source/packages/services/device-patcher/src/di/inversify.config.ts
+++ b/source/packages/services/device-patcher/src/di/inversify.config.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
 import '@awssolutions/cdf-config-inject';
-import { version } from '@awssolutions/cdf-version';
+import { getCustomUserAgent } from '@awssolutions/cdf-attribution';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 import 'reflect-metadata';
 
@@ -100,7 +100,7 @@ container.bind<DynamoDbUtils>(TYPES.DynamoDbUtils).to(DynamoDbUtils).inSingleton
 container.bind<ExpressionParser>(TYPES.ExpressionParser).to(ExpressionParser).inSingletonScope();
 
 AWS.config.update({
-    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_dvp`,
+    customUserAgent: getCustomUserAgent('dvp'),
 });
 
 // for 3rd party objects, we need to use factory injectors

--- a/source/packages/services/events-alerts/package.json
+++ b/source/packages/services/events-alerts/package.json
@@ -78,6 +78,6 @@
     "winston-transport": "4.4.0"
   },
   "dependencies": {
-    "@awssolutions/cdf-version": "workspace:~0.0.0"
+    "@awssolutions/cdf-attribution": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/events-alerts/package.json
+++ b/source/packages/services/events-alerts/package.json
@@ -76,5 +76,8 @@
     "uuid": "8.3.2",
     "winston": "3.3.3",
     "winston-transport": "4.4.0"
+  },
+  "dependencies": {
+    "@awssolutions/cdf-version": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/events-alerts/src/di/inversify.config.ts
+++ b/source/packages/services/events-alerts/src/di/inversify.config.ts
@@ -14,7 +14,7 @@ import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
 
-import { version } from '@awssolutions/cdf-version';
+import { getCustomUserAgent } from '@awssolutions/cdf-attribution';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 import { AlertAssembler } from '../alerts/assembler';
@@ -60,7 +60,7 @@ container
 container.bind<AlertAssembler>(TYPES.AlertAssembler).to(AlertAssembler).inSingletonScope();
 
 AWS.config.update({
-    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ntfa`,
+    customUserAgent: getCustomUserAgent('ntfa'),
 });
 
 // for 3rd party objects, we need to use factory injectors

--- a/source/packages/services/events-alerts/src/di/inversify.config.ts
+++ b/source/packages/services/events-alerts/src/di/inversify.config.ts
@@ -14,6 +14,7 @@ import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
 
+import { version } from '@awssolutions/cdf-version';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 import { AlertAssembler } from '../alerts/assembler';
@@ -57,6 +58,10 @@ container
     .inSingletonScope();
 
 container.bind<AlertAssembler>(TYPES.AlertAssembler).to(AlertAssembler).inSingletonScope();
+
+AWS.config.update({
+    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ntfa`,
+});
 
 // for 3rd party objects, we need to use factory injectors
 

--- a/source/packages/services/events-processor/package.json
+++ b/source/packages/services/events-processor/package.json
@@ -88,5 +88,8 @@
     "uuid": "8.3.2",
     "winston": "3.3.3",
     "winston-transport": "4.4.0"
+  },
+  "dependencies": {
+    "@awssolutions/cdf-version": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/events-processor/package.json
+++ b/source/packages/services/events-processor/package.json
@@ -90,6 +90,6 @@
     "winston-transport": "4.4.0"
   },
   "dependencies": {
-    "@awssolutions/cdf-version": "workspace:~0.0.0"
+    "@awssolutions/cdf-attribution": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/events-processor/src/di/inversify.config.ts
+++ b/source/packages/services/events-processor/src/di/inversify.config.ts
@@ -14,6 +14,7 @@ import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
 
+import { version } from '@awssolutions/cdf-version';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 // Note: importing @controller's carries out a one time inversify metadata generation...
@@ -152,6 +153,10 @@ container.bind<SMSTarget>(TYPES.SMSTarget).to(SMSTarget).inSingletonScope();
 container.bind<PushTarget>(TYPES.PushTarget).to(PushTarget).inSingletonScope();
 
 container.bind<DynamoDbUtils>(TYPES.DynamoDbUtils).to(DynamoDbUtils).inSingletonScope();
+
+AWS.config.update({
+    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ntfp`,
+});
 
 // for 3rd party objects, we need to use factory injectors
 

--- a/source/packages/services/events-processor/src/di/inversify.config.ts
+++ b/source/packages/services/events-processor/src/di/inversify.config.ts
@@ -14,7 +14,7 @@ import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
 
-import { version } from '@awssolutions/cdf-version';
+import { getCustomUserAgent } from '@awssolutions/cdf-attribution';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 // Note: importing @controller's carries out a one time inversify metadata generation...
@@ -155,7 +155,7 @@ container.bind<PushTarget>(TYPES.PushTarget).to(PushTarget).inSingletonScope();
 container.bind<DynamoDbUtils>(TYPES.DynamoDbUtils).to(DynamoDbUtils).inSingletonScope();
 
 AWS.config.update({
-    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ntfp`,
+    customUserAgent: getCustomUserAgent('ntfp'),
 });
 
 // for 3rd party objects, we need to use factory injectors

--- a/source/packages/services/greengrass2-provisioning/package.json
+++ b/source/packages/services/greengrass2-provisioning/package.json
@@ -106,6 +106,6 @@
     "winston-transport": "4.4.0"
   },
   "dependencies": {
-    "@awssolutions/cdf-version": "workspace:~0.0.0"
+    "@awssolutions/cdf-attribution": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/greengrass2-provisioning/package.json
+++ b/source/packages/services/greengrass2-provisioning/package.json
@@ -104,5 +104,8 @@
     "typescript": "4.2.4",
     "winston": "3.3.3",
     "winston-transport": "4.4.0"
+  },
+  "dependencies": {
+    "@awssolutions/cdf-version": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/greengrass2-provisioning/src/di/inversify.config.ts
+++ b/source/packages/services/greengrass2-provisioning/src/di/inversify.config.ts
@@ -14,6 +14,7 @@ import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
 
+import { version } from '@awssolutions/cdf-version';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
@@ -131,7 +132,10 @@ container
     .toFactory<DynamoDBClient>(() => {
         return () => {
             if (!container.isBound(TYPES.DynamoDB)) {
-                const ddb = new DynamoDBClient({ region: process.env.AWS_REGION });
+                const ddb = new DynamoDBClient({
+                    region: process.env.AWS_REGION,
+                    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ggp`,
+                });
                 container.bind<DynamoDBClient>(TYPES.DynamoDB).toConstantValue(ddb);
             }
             return container.get<DynamoDBClient>(TYPES.DynamoDB);
@@ -175,7 +179,10 @@ decorate(injectable(), SQSClient);
 container.bind<interfaces.Factory<SQSClient>>(TYPES.SQSFactory).toFactory<SQSClient>(() => {
     return () => {
         if (!container.isBound(TYPES.SQS)) {
-            const sqs = new SQSClient({ region: process.env.AWS_REGION });
+            const sqs = new SQSClient({
+                region: process.env.AWS_REGION,
+                customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ggp`,
+            });
             container.bind<SQSClient>(TYPES.SQS).toConstantValue(sqs);
         }
         return container.get<SQSClient>(TYPES.SQS);
@@ -186,7 +193,10 @@ decorate(injectable(), S3Client);
 container.bind<interfaces.Factory<S3Client>>(TYPES.S3Factory).toFactory<S3Client>(() => {
     return () => {
         if (!container.isBound(TYPES.S3)) {
-            const s3 = new S3Client({ region: process.env.AWS_REGION });
+            const s3 = new S3Client({
+                region: process.env.AWS_REGION,
+                customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ggp`,
+            });
             container.bind<S3Client>(TYPES.S3).toConstantValue(s3);
         }
         return container.get<S3Client>(TYPES.S3);
@@ -197,7 +207,10 @@ decorate(injectable(), IoTClient);
 container.bind<interfaces.Factory<IoTClient>>(TYPES.IotFactory).toFactory<IoTClient>(() => {
     return () => {
         if (!container.isBound(TYPES.Iot)) {
-            const iot = new IoTClient({ region: process.env.AWS_REGION });
+            const iot = new IoTClient({
+                region: process.env.AWS_REGION,
+                customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ggp`,
+            });
             container.bind<IoTClient>(TYPES.Iot).toConstantValue(iot);
         }
         return container.get<IoTClient>(TYPES.Iot);
@@ -212,7 +225,10 @@ container
     .toFactory<GreengrassV2Client>(() => {
         return () => {
             if (!container.isBound(TYPES.Greengrassv2)) {
-                const ggv2 = new GreengrassV2Client({ region: process.env.AWS_REGION });
+                const ggv2 = new GreengrassV2Client({
+                    region: process.env.AWS_REGION,
+                    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ggp`,
+                });
                 container.bind<GreengrassV2Client>(TYPES.Greengrassv2).toConstantValue(ggv2);
             }
             return container.get<GreengrassV2Client>(TYPES.Greengrassv2);
@@ -225,7 +241,10 @@ container
     .toFactory<LambdaClient>(() => {
         return () => {
             if (!container.isBound(TYPES.Lambda)) {
-                const l = new LambdaClient({ region: process.env.AWS_REGION });
+                const l = new LambdaClient({
+                    region: process.env.AWS_REGION,
+                    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ggp`,
+                });
                 container.bind<LambdaClient>(TYPES.Lambda).toConstantValue(l);
             }
             return container.get<LambdaClient>(TYPES.Lambda);

--- a/source/packages/services/greengrass2-provisioning/src/di/inversify.config.ts
+++ b/source/packages/services/greengrass2-provisioning/src/di/inversify.config.ts
@@ -14,7 +14,7 @@ import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
 
-import { version } from '@awssolutions/cdf-version';
+import { getCustomUserAgent } from '@awssolutions/cdf-attribution';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
@@ -134,7 +134,7 @@ container
             if (!container.isBound(TYPES.DynamoDB)) {
                 const ddb = new DynamoDBClient({
                     region: process.env.AWS_REGION,
-                    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ggp`,
+                    customUserAgent: getCustomUserAgent('ggp'),
                 });
                 container.bind<DynamoDBClient>(TYPES.DynamoDB).toConstantValue(ddb);
             }
@@ -181,7 +181,7 @@ container.bind<interfaces.Factory<SQSClient>>(TYPES.SQSFactory).toFactory<SQSCli
         if (!container.isBound(TYPES.SQS)) {
             const sqs = new SQSClient({
                 region: process.env.AWS_REGION,
-                customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ggp`,
+                customUserAgent: getCustomUserAgent('ggp'),
             });
             container.bind<SQSClient>(TYPES.SQS).toConstantValue(sqs);
         }
@@ -195,7 +195,7 @@ container.bind<interfaces.Factory<S3Client>>(TYPES.S3Factory).toFactory<S3Client
         if (!container.isBound(TYPES.S3)) {
             const s3 = new S3Client({
                 region: process.env.AWS_REGION,
-                customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ggp`,
+                customUserAgent: getCustomUserAgent('ggp'),
             });
             container.bind<S3Client>(TYPES.S3).toConstantValue(s3);
         }
@@ -209,7 +209,7 @@ container.bind<interfaces.Factory<IoTClient>>(TYPES.IotFactory).toFactory<IoTCli
         if (!container.isBound(TYPES.Iot)) {
             const iot = new IoTClient({
                 region: process.env.AWS_REGION,
-                customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ggp`,
+                customUserAgent: getCustomUserAgent('ggp'),
             });
             container.bind<IoTClient>(TYPES.Iot).toConstantValue(iot);
         }
@@ -227,7 +227,7 @@ container
             if (!container.isBound(TYPES.Greengrassv2)) {
                 const ggv2 = new GreengrassV2Client({
                     region: process.env.AWS_REGION,
-                    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ggp`,
+                    customUserAgent: getCustomUserAgent('ggp'),
                 });
                 container.bind<GreengrassV2Client>(TYPES.Greengrassv2).toConstantValue(ggv2);
             }
@@ -243,7 +243,7 @@ container
             if (!container.isBound(TYPES.Lambda)) {
                 const l = new LambdaClient({
                     region: process.env.AWS_REGION,
-                    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ggp`,
+                    customUserAgent: getCustomUserAgent('ggp'),
                 });
                 container.bind<LambdaClient>(TYPES.Lambda).toConstantValue(l);
             }

--- a/source/packages/services/organization-manager/package.json
+++ b/source/packages/services/organization-manager/package.json
@@ -90,5 +90,8 @@
     "typescript": "4.2.4",
     "winston": "3.3.3",
     "winston-transport": "4.4.0"
+  },
+  "dependencies": {
+    "@awssolutions/cdf-version": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/organization-manager/package.json
+++ b/source/packages/services/organization-manager/package.json
@@ -92,6 +92,6 @@
     "winston-transport": "4.4.0"
   },
   "dependencies": {
-    "@awssolutions/cdf-version": "workspace:~0.0.0"
+    "@awssolutions/cdf-attribution": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/organization-manager/src/di/inversify.config.ts
+++ b/source/packages/services/organization-manager/src/di/inversify.config.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
 import '@awssolutions/cdf-config-inject';
-import { version } from '@awssolutions/cdf-version';
+import { getCustomUserAgent } from '@awssolutions/cdf-attribution';
 import AWS from 'aws-sdk';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 import { HttpHeaderUtils } from '../utils/httpHeaders';
@@ -104,7 +104,7 @@ const managementAccountCredentials = new AWS.ChainableTemporaryCredentials({
 });
 
 AWS.config.update({
-    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ogm`,
+    customUserAgent: getCustomUserAgent('ogm'),
 });
 
 // for 3rd party objects, we need to use factory injectors

--- a/source/packages/services/organization-manager/src/di/inversify.config.ts
+++ b/source/packages/services/organization-manager/src/di/inversify.config.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.                                                                                *
  *********************************************************************************************************************/
 import '@awssolutions/cdf-config-inject';
+import { version } from '@awssolutions/cdf-version';
 import AWS from 'aws-sdk';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 import { HttpHeaderUtils } from '../utils/httpHeaders';
@@ -100,6 +101,10 @@ const managementAccountCredentials = new AWS.ChainableTemporaryCredentials({
         RoleArn: process.env.MANAGEMENT_ACCOUNT_ASSUME_ROLE,
         RoleSessionName: `cdf-organization-assume-management`,
     },
+});
+
+AWS.config.update({
+    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_ogm`,
 });
 
 // for 3rd party objects, we need to use factory injectors

--- a/source/packages/services/provisioning/package.json
+++ b/source/packages/services/provisioning/package.json
@@ -88,5 +88,8 @@
     "uuid": "8.3.2",
     "winston": "3.3.3",
     "winston-transport": "4.4.0"
+  },
+  "dependencies": {
+    "@awssolutions/cdf-version": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/provisioning/package.json
+++ b/source/packages/services/provisioning/package.json
@@ -90,6 +90,6 @@
     "winston-transport": "4.4.0"
   },
   "dependencies": {
-    "@awssolutions/cdf-version": "workspace:~0.0.0"
+    "@awssolutions/cdf-attribution": "workspace:~0.0.0"
   }
 }

--- a/source/packages/services/provisioning/src/di/inversify.config.ts
+++ b/source/packages/services/provisioning/src/di/inversify.config.ts
@@ -14,6 +14,7 @@ import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
 
+import { version } from '@awssolutions/cdf-version';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 // Note: importing @controller's carries out a one time inversify metadata generation...
@@ -93,6 +94,10 @@ container
     .bind<AttachAdditionalPoliciesProcessor>(TYPES.AttachAdditionalPoliciesProcessor)
     .to(AttachAdditionalPoliciesProcessor)
     .inSingletonScope();
+
+AWS.config.update({
+    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_prv`,
+});
 
 // for 3rd party objects, we need to use factory injectors
 // IoT

--- a/source/packages/services/provisioning/src/di/inversify.config.ts
+++ b/source/packages/services/provisioning/src/di/inversify.config.ts
@@ -14,7 +14,7 @@ import 'reflect-metadata';
 
 import '@awssolutions/cdf-config-inject';
 
-import { version } from '@awssolutions/cdf-version';
+import { getCustomUserAgent } from '@awssolutions/cdf-attribution';
 import { Container, decorate, injectable, interfaces } from 'inversify';
 
 // Note: importing @controller's carries out a one time inversify metadata generation...
@@ -96,7 +96,7 @@ container
     .inSingletonScope();
 
 AWS.config.update({
-    customUserAgent: `awssolutions/99CF47E5-1F4E-4DB2-AB43-0E975D0C7888_${version}_prv`,
+    customUserAgent: getCustomUserAgent('prv'),
 });
 
 // for 3rd party objects, we need to use factory injectors

--- a/source/rush.json
+++ b/source/rush.json
@@ -147,6 +147,12 @@
       "versionPolicyName": "internal"
     },
     {
+      "packageName": "@awssolutions/cdf-attribution",
+      "projectFolder": "packages/libraries/core/attribution",
+      "reviewCategory": "library",
+      "versionPolicyName": "internal"
+    },
+    {
       "packageName": "@awssolutions/eslint-config-custom",
       "projectFolder": "packages/libraries/config/eslint-config-custom",
       "reviewCategory": "library",


### PR DESCRIPTION
# Description
This PR add custom user agent header string to AWS SDK clients code. The following method is used as follow:
- If there is _one and only one_ AWS SDK client in the `inversify.config.ts`, directly update the client option
- If there is more than one AWS SDK clients in the `inversify.config.ts`, use `AWS.config.update` to update global config

## Type of change

- [ ] *Bug fix (non-breaking change which fixes an issue)*
- [x] *New feature (non-breaking change which adds functionality)*
- [ ] *Breaking change (fix or feature that would cause existing functionality to not work as expected)*
- [ ] *Refactor* (existing code being refactored)
- [ ] *This change includes a documentation update*

# Submission Checklist

- [x] CI dry-run passing
- [ ] Integration tests passing locally
  - N/A
- [ ] Change logs generated 
  - N/A

<!-- Refer to the development getting started doc to learn more source/docs/development/quickstart.md -->

##### Additional Notes:
<!-- Any additional information that you think would be helpful when reviewing this PR.-->
